### PR TITLE
postgres support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -163,11 +163,12 @@ dependencies = [
  "clap",
  "cornucopia_client",
  "eui48",
- "futures",
+ "fallible-iterator",
  "heck",
  "indexmap",
  "pest",
  "pest_derive",
+ "postgres",
  "postgres-types",
  "prettyplease",
  "serde",
@@ -175,8 +176,6 @@ dependencies = [
  "syn",
  "thiserror",
  "time",
- "tokio",
- "tokio-postgres",
  "uuid",
 ]
 
@@ -210,6 +209,7 @@ dependencies = [
  "async-trait",
  "deadpool-postgres",
  "fallible-iterator",
+ "postgres",
  "postgres-protocol",
  "tokio",
  "tokio-postgres",
@@ -677,6 +677,20 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "postgres"
+version = "0.19.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8bbcd5f6deb39585a0d9f4ef34c4a41c25b7ad26d23c75d837d78c8e7adc85f"
+dependencies = [
+ "bytes",
+ "fallible-iterator",
+ "futures",
+ "log",
+ "tokio",
+ "tokio-postgres",
+]
 
 [[package]]
 name = "postgres-derive"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,8 @@ members = ["examples/*", "cornucopia_client"]
 
 [dependencies]
 cornucopia_client = { path = "cornucopia_client" }
-futures = "0.3.21"
-tokio = { version = "1.18.2", features = ["full"] }
-tokio-postgres = { version = "0.7.6", features = [
+fallible-iterator = "0.2.0"
+postgres = { version = "0.19.3", features = [
     "with-serde_json-1",
     "with-time-0_3",
     "with-uuid-1",

--- a/cornucopia_client/Cargo.toml
+++ b/cornucopia_client/Cargo.toml
@@ -16,6 +16,7 @@ keywords = ["postgresql", "query", "generator", "sql", "tokio-postgres"]
 tokio = { version = "1.18.1", features = ["full"] }
 deadpool-postgres = "0.10.2"
 tokio-postgres = "0.7.6"
+postgres = "0.19.3"
 async-trait = "0.1.53"
 fallible-iterator = "0.2.0"
 postgres-protocol = "0.6.4"

--- a/cornucopia_client/src/lib.rs
+++ b/cornucopia_client/src/lib.rs
@@ -1,11 +1,9 @@
 use std::marker::PhantomData;
 
 use async_trait::async_trait;
-//use byteorder::{BigEndian, ReadBytesExt};
 use deadpool_postgres::{Client, ClientWrapper, Transaction};
 use fallible_iterator::FallibleIterator;
 use postgres_protocol::types::{array_from_sql, ArrayValues};
-//use fallible_iterator::FallibleIterator;
 use tokio_postgres::{
     types::{BorrowToSql, FromSql, Kind, ToSql, Type},
     Client as PgClient, Error, RowStream, Statement, ToStatement, Transaction as PgTransaction,

--- a/examples/auto_build/src/cornucopia.rs
+++ b/examples/auto_build/src/cornucopia.rs
@@ -2,6 +2,7 @@ pub mod types {}
 pub mod queries {
     pub mod module_1 {
         use futures::{StreamExt, TryStreamExt};
+        use cornucopia_client::GenericClient;
         pub struct ExampleQueryBorrowed<'a> {
             pub col1: &'a str,
         }
@@ -14,9 +15,9 @@ pub mod queries {
                 Self { col1: col1.into() }
             }
         }
-        pub struct ExampleQueryQuery<'a, C: cornucopia_client::GenericClient, T> {
+        pub struct ExampleQueryQuery<'a, C: GenericClient, T> {
             client: &'a C,
-            params: [&'a (dyn tokio_postgres::types::ToSql + Sync); 0],
+            params: [&'a (dyn postgres_types::ToSql + Sync); 0],
             mapper: fn(ExampleQueryBorrowed) -> T,
         }
         impl<'a, C, T> ExampleQueryQuery<'a, C, T>
@@ -81,7 +82,7 @@ FROM
                 Ok(stream.into_stream())
             }
         }
-        pub fn example_query<'a, C: cornucopia_client::GenericClient>(
+        pub fn example_query<'a, C: GenericClient>(
             client: &'a C,
         ) -> ExampleQueryQuery<'a, C, ExampleQuery> {
             ExampleQueryQuery {

--- a/examples/basic/src/cornucopia.rs
+++ b/examples/basic/src/cornucopia.rs
@@ -127,52 +127,9 @@ pub mod types {
     }
 }
 pub mod queries {
-    pub mod module_1 {
-        use futures::{StreamExt, TryStreamExt};
-        pub struct InsertBookParams<'a> {
-            pub title: &'a str,
-        }
-        impl<'a> InsertBookParams<'a> {
-            pub fn query<C: cornucopia_client::GenericClient>(
-                &'a self,
-                client: &'a C,
-            ) -> InsertBookQuery<'a, C> {
-                insert_book(client, &self.title)
-            }
-        }
-        pub struct InsertBookQuery<'a, C: cornucopia_client::GenericClient> {
-            client: &'a C,
-            params: [&'a (dyn tokio_postgres::types::ToSql + Sync); 1],
-        }
-        impl<'a, C> InsertBookQuery<'a, C>
-        where
-            C: cornucopia_client::GenericClient,
-        {
-            pub async fn stmt(
-                &self,
-            ) -> Result<tokio_postgres::Statement, tokio_postgres::Error> {
-                self.client.prepare("INSERT INTO Book (title)
-  VALUES ($1);
-
-").await
-            }
-            pub async fn exec(self) -> Result<u64, tokio_postgres::Error> {
-                let stmt = self.stmt().await?;
-                self.client.execute(&stmt, &self.params).await
-            }
-        }
-        pub fn insert_book<'a, C: cornucopia_client::GenericClient>(
-            client: &'a C,
-            title: &'a &str,
-        ) -> InsertBookQuery<'a, C> {
-            InsertBookQuery {
-                client,
-                params: [title],
-            }
-        }
-    }
     pub mod module_2 {
         use futures::{StreamExt, TryStreamExt};
+        use cornucopia_client::GenericClient;
         pub struct AuthorsBorrowed<'a> {
             pub id: i32,
             pub name: &'a str,
@@ -193,9 +150,9 @@ pub mod queries {
                 }
             }
         }
-        pub struct AuthorsQuery<'a, C: cornucopia_client::GenericClient, T> {
+        pub struct AuthorsQuery<'a, C: GenericClient, T> {
             client: &'a C,
-            params: [&'a (dyn tokio_postgres::types::ToSql + Sync); 0],
+            params: [&'a (dyn postgres_types::ToSql + Sync); 0],
             mapper: fn(AuthorsBorrowed) -> T,
         }
         impl<'a, C, T> AuthorsQuery<'a, C, T>
@@ -260,7 +217,7 @@ FROM
                 Ok(stream.into_stream())
             }
         }
-        pub fn authors<'a, C: cornucopia_client::GenericClient>(
+        pub fn authors<'a, C: GenericClient>(
             client: &'a C,
         ) -> AuthorsQuery<'a, C, Authors> {
             AuthorsQuery {
@@ -281,9 +238,9 @@ FROM
                 Self { title: title.into() }
             }
         }
-        pub struct BooksQuery<'a, C: cornucopia_client::GenericClient, T> {
+        pub struct BooksQuery<'a, C: GenericClient, T> {
             client: &'a C,
-            params: [&'a (dyn tokio_postgres::types::ToSql + Sync); 0],
+            params: [&'a (dyn postgres_types::ToSql + Sync); 0],
             mapper: fn(BooksBorrowed) -> T,
         }
         impl<'a, C, T> BooksQuery<'a, C, T>
@@ -341,9 +298,7 @@ FROM
                 Ok(stream.into_stream())
             }
         }
-        pub fn books<'a, C: cornucopia_client::GenericClient>(
-            client: &'a C,
-        ) -> BooksQuery<'a, C, Books> {
+        pub fn books<'a, C: GenericClient>(client: &'a C) -> BooksQuery<'a, C, Books> {
             BooksQuery {
                 client,
                 params: [],
@@ -366,9 +321,9 @@ FROM
                 }
             }
         }
-        pub struct BooksOptRetParamQuery<'a, C: cornucopia_client::GenericClient, T> {
+        pub struct BooksOptRetParamQuery<'a, C: GenericClient, T> {
             client: &'a C,
-            params: [&'a (dyn tokio_postgres::types::ToSql + Sync); 0],
+            params: [&'a (dyn postgres_types::ToSql + Sync); 0],
             mapper: fn(BooksOptRetParamBorrowed) -> T,
         }
         impl<'a, C, T> BooksOptRetParamQuery<'a, C, T>
@@ -433,7 +388,7 @@ FROM
                 Ok(stream.into_stream())
             }
         }
-        pub fn books_opt_ret_param<'a, C: cornucopia_client::GenericClient>(
+        pub fn books_opt_ret_param<'a, C: GenericClient>(
             client: &'a C,
         ) -> BooksOptRetParamQuery<'a, C, BooksOptRetParam> {
             BooksOptRetParamQuery {
@@ -447,7 +402,7 @@ FROM
             pub id: i32,
         }
         impl AuthorNameByIdParams {
-            pub fn query<'a, C: cornucopia_client::GenericClient>(
+            pub fn query<'a, C: GenericClient>(
                 &'a self,
                 client: &'a C,
             ) -> AuthorNameByIdQuery<'a, C, AuthorNameById> {
@@ -468,9 +423,9 @@ FROM
                 Self { name: name.into() }
             }
         }
-        pub struct AuthorNameByIdQuery<'a, C: cornucopia_client::GenericClient, T> {
+        pub struct AuthorNameByIdQuery<'a, C: GenericClient, T> {
             client: &'a C,
-            params: [&'a (dyn tokio_postgres::types::ToSql + Sync); 1],
+            params: [&'a (dyn postgres_types::ToSql + Sync); 1],
             mapper: fn(AuthorNameByIdBorrowed) -> T,
         }
         impl<'a, C, T> AuthorNameByIdQuery<'a, C, T>
@@ -539,7 +494,7 @@ WHERE
                 Ok(stream.into_stream())
             }
         }
-        pub fn author_name_by_id<'a, C: cornucopia_client::GenericClient>(
+        pub fn author_name_by_id<'a, C: GenericClient>(
             client: &'a C,
             id: &'a i32,
         ) -> AuthorNameByIdQuery<'a, C, AuthorNameById> {
@@ -553,7 +508,7 @@ WHERE
             pub start_str: &'a str,
         }
         impl<'a> AuthorNameStartingWithParams<'a> {
-            pub fn query<C: cornucopia_client::GenericClient>(
+            pub fn query<C: GenericClient>(
                 &'a self,
                 client: &'a C,
             ) -> AuthorNameStartingWithQuery<'a, C, AuthorNameStartingWith> {
@@ -590,13 +545,9 @@ WHERE
                 }
             }
         }
-        pub struct AuthorNameStartingWithQuery<
-            'a,
-            C: cornucopia_client::GenericClient,
-            T,
-        > {
+        pub struct AuthorNameStartingWithQuery<'a, C: GenericClient, T> {
             client: &'a C,
-            params: [&'a (dyn tokio_postgres::types::ToSql + Sync); 1],
+            params: [&'a (dyn postgres_types::ToSql + Sync); 1],
             mapper: fn(AuthorNameStartingWithBorrowed) -> T,
         }
         impl<'a, C, T> AuthorNameStartingWithQuery<'a, C, T>
@@ -675,7 +626,7 @@ WHERE
                 Ok(stream.into_stream())
             }
         }
-        pub fn author_name_starting_with<'a, C: cornucopia_client::GenericClient>(
+        pub fn author_name_starting_with<'a, C: GenericClient>(
             client: &'a C,
             start_str: &'a &str,
         ) -> AuthorNameStartingWithQuery<'a, C, AuthorNameStartingWith> {
@@ -699,9 +650,9 @@ WHERE
                 Self { col1: col1.into() }
             }
         }
-        pub struct ReturnCustomTypeQuery<'a, C: cornucopia_client::GenericClient, T> {
+        pub struct ReturnCustomTypeQuery<'a, C: GenericClient, T> {
             client: &'a C,
-            params: [&'a (dyn tokio_postgres::types::ToSql + Sync); 0],
+            params: [&'a (dyn postgres_types::ToSql + Sync); 0],
             mapper: fn(ReturnCustomTypeBorrowed) -> T,
         }
         impl<'a, C, T> ReturnCustomTypeQuery<'a, C, T>
@@ -766,7 +717,7 @@ FROM
                 Ok(stream.into_stream())
             }
         }
-        pub fn return_custom_type<'a, C: cornucopia_client::GenericClient>(
+        pub fn return_custom_type<'a, C: GenericClient>(
             client: &'a C,
         ) -> ReturnCustomTypeQuery<'a, C, ReturnCustomType> {
             ReturnCustomTypeQuery {
@@ -780,7 +731,7 @@ FROM
             pub spongebob_character: super::super::types::public::SpongebobCharacter,
         }
         impl SelectWhereCustomTypeParams {
-            pub fn query<'a, C: cornucopia_client::GenericClient>(
+            pub fn query<'a, C: GenericClient>(
                 &'a self,
                 client: &'a C,
             ) -> SelectWhereCustomTypeQuery<'a, C, SelectWhereCustomType> {
@@ -791,13 +742,9 @@ FROM
         pub struct SelectWhereCustomType {
             pub col2: super::super::types::public::SpongebobCharacter,
         }
-        pub struct SelectWhereCustomTypeQuery<
-            'a,
-            C: cornucopia_client::GenericClient,
-            T,
-        > {
+        pub struct SelectWhereCustomTypeQuery<'a, C: GenericClient, T> {
             client: &'a C,
-            params: [&'a (dyn tokio_postgres::types::ToSql + Sync); 1],
+            params: [&'a (dyn postgres_types::ToSql + Sync); 1],
             mapper: fn(SelectWhereCustomType) -> T,
         }
         impl<'a, C, T> SelectWhereCustomTypeQuery<'a, C, T>
@@ -865,7 +812,7 @@ WHERE (col1).persona = $1;",
                 Ok(stream.into_stream())
             }
         }
-        pub fn select_where_custom_type<'a, C: cornucopia_client::GenericClient>(
+        pub fn select_where_custom_type<'a, C: GenericClient>(
             client: &'a C,
             spongebob_character: &'a super::super::types::public::SpongebobCharacter,
         ) -> SelectWhereCustomTypeQuery<'a, C, SelectWhereCustomType> {
@@ -893,9 +840,9 @@ WHERE (col1).persona = $1;",
                 }
             }
         }
-        pub struct SelectTranslationsQuery<'a, C: cornucopia_client::GenericClient, T> {
+        pub struct SelectTranslationsQuery<'a, C: GenericClient, T> {
             client: &'a C,
-            params: [&'a (dyn tokio_postgres::types::ToSql + Sync); 0],
+            params: [&'a (dyn postgres_types::ToSql + Sync); 0],
             mapper: fn(SelectTranslationsBorrowed) -> T,
         }
         impl<'a, C, T> SelectTranslationsQuery<'a, C, T>
@@ -962,13 +909,58 @@ FROM
                 Ok(stream.into_stream())
             }
         }
-        pub fn select_translations<'a, C: cornucopia_client::GenericClient>(
+        pub fn select_translations<'a, C: GenericClient>(
             client: &'a C,
         ) -> SelectTranslationsQuery<'a, C, SelectTranslations> {
             SelectTranslationsQuery {
                 client,
                 params: [],
                 mapper: |it| SelectTranslations::from(it),
+            }
+        }
+    }
+    pub mod module_1 {
+        use futures::{StreamExt, TryStreamExt};
+        use cornucopia_client::GenericClient;
+        pub struct InsertBookParams<'a> {
+            pub title: &'a str,
+        }
+        impl<'a> InsertBookParams<'a> {
+            pub fn query<C: GenericClient>(
+                &'a self,
+                client: &'a C,
+            ) -> InsertBookQuery<'a, C> {
+                insert_book(client, &self.title)
+            }
+        }
+        pub struct InsertBookQuery<'a, C: GenericClient> {
+            client: &'a C,
+            params: [&'a (dyn postgres_types::ToSql + Sync); 1],
+        }
+        impl<'a, C> InsertBookQuery<'a, C>
+        where
+            C: cornucopia_client::GenericClient,
+        {
+            pub async fn stmt(
+                &self,
+            ) -> Result<tokio_postgres::Statement, tokio_postgres::Error> {
+                self.client.prepare("INSERT INTO Book (title)
+  VALUES ($1);
+
+").await
+            }
+            pub async fn exec(self) -> Result<u64, tokio_postgres::Error> {
+                let stmt = self.stmt().await?;
+                self.client.execute(&stmt, &self.params).await
+            }
+        }
+        pub fn insert_book<'a, C: GenericClient>(
+            client: &'a C,
+            title: &'a &str,
+        ) -> InsertBookQuery<'a, C> {
+            InsertBookQuery {
+                client,
+                params: [title],
             }
         }
     }

--- a/src/conn.rs
+++ b/src/conn.rs
@@ -1,32 +1,17 @@
-use std::str::FromStr;
-use tokio_postgres::{Client, Config, Error, NoTls};
+use postgres::{Client, Config, Error, NoTls};
 
 /// Creates a non-TLS connection from a URL.
-pub(crate) async fn from_url(url: &str) -> Result<Client, Error> {
-    let config = tokio_postgres::Config::from_str(url)?;
-    from_config(&config).await
+pub(crate) fn from_url(url: &str) -> Result<Client, Error> {
+    Client::connect(url, NoTls)
 }
 
 /// Create a non-TLS connection for usage internal to Cornucopia.
-pub(crate) async fn cornucopia_conn() -> Result<Client, Error> {
-    from_config(
-        Config::new()
-            .user("postgres")
-            .password("postgres")
-            .host("127.0.0.1")
-            .port(5432)
-            .dbname("postgres"),
-    )
-    .await
-}
-
-async fn from_config(config: &Config) -> Result<Client, Error> {
-    // Connect to the database.
-    let (client, connection) = config.connect(NoTls).await?;
-
-    // The connection object performs the actual communication with the database,
-    // so spawn it off to run on its own.
-    tokio::spawn(connection);
-
-    Ok(client)
+pub(crate) fn cornucopia_conn() -> Result<Client, Error> {
+    Config::new()
+        .user("postgres")
+        .password("postgres")
+        .host("127.0.0.1")
+        .port(5432)
+        .dbname("postgres")
+        .connect(NoTls)
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -14,5 +14,5 @@ pub(crate) enum Error {
     PrepareQueries(#[from] PrepareQueriesError),
     NewMigration(#[from] std::io::Error),
     Migration(#[from] MigrationError),
-    Db(#[from] tokio_postgres::Error),
+    Db(#[from] postgres::Error),
 }

--- a/src/integration/cornucopia.rs
+++ b/src/integration/cornucopia.rs
@@ -825,7 +825,7 @@ FROM
             pub fn query<C: GenericClient>(
                 &'a self,
                 client: &'a mut C,
-            ) -> InsertEverythingQuery<'a, C> {
+            ) -> Result<u64, postgres::Error> {
                 insert_everything(
                     client,
                     &self.custom_domain_,
@@ -868,28 +868,6 @@ FROM
                 )
             }
         }
-        pub struct InsertEverythingQuery<'a, C: GenericClient> {
-            client: &'a mut C,
-            params: [&'a (dyn postgres_types::ToSql + Sync); 37],
-        }
-        impl<'a, C> InsertEverythingQuery<'a, C>
-        where
-            C: GenericClient,
-        {
-            pub fn stmt(&mut self) -> Result<postgres::Statement, postgres::Error> {
-                self.client
-                    .prepare(
-                        "INSERT INTO Everything (custom_domain_, custom_array_, domain_, array_, bool_, boolean_, char_, smallint_, int2_, smallserial_, serial2_, int_, int4_, serial_, serial4_, bingint_, int8_, bigserial_, serial8_, float4_, real_, float8_, double_precision_, text_, varchar_, bytea_, timestamp_, timestamp_without_time_zone_, timestamptz_, timestamp_with_time_zone_, date_, time_, json_, jsonb_, uuid_, inet_, macaddr_)
-    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37);
-
-",
-                    )
-            }
-            pub fn exec(mut self) -> Result<u64, postgres::Error> {
-                let stmt = self.stmt()?;
-                self.client.execute(&stmt, &self.params)
-            }
-        }
         pub fn insert_everything<'a, C: GenericClient>(
             client: &'a mut C,
             custom_domain_: &'a super::super::types::public::CustomDomain,
@@ -929,49 +907,57 @@ FROM
             uuid_: &'a uuid::Uuid,
             inet_: &'a std::net::IpAddr,
             macaddr_: &'a eui48::MacAddress,
-        ) -> InsertEverythingQuery<'a, C> {
-            InsertEverythingQuery {
-                client,
-                params: [
-                    custom_domain_,
-                    custom_array_,
-                    domain_,
-                    array_,
-                    bool_,
-                    boolean_,
-                    char_,
-                    smallint_,
-                    int2_,
-                    smallserial_,
-                    serial2_,
-                    int_,
-                    int4_,
-                    serial_,
-                    serial4_,
-                    bingint_,
-                    int8_,
-                    bigserial_,
-                    serial8_,
-                    float4_,
-                    real_,
-                    float8_,
-                    double_precision_,
-                    text_,
-                    varchar_,
-                    bytea_,
-                    timestamp_,
-                    timestamp_without_time_zone_,
-                    timestamptz_,
-                    timestamp_with_time_zone_,
-                    date_,
-                    time_,
-                    json_,
-                    jsonb_,
-                    uuid_,
-                    inet_,
-                    macaddr_,
-                ],
-            }
+        ) -> Result<u64, postgres::Error> {
+            let stmt = client
+                .prepare(
+                    "INSERT INTO Everything (custom_domain_, custom_array_, domain_, array_, bool_, boolean_, char_, smallint_, int2_, smallserial_, serial2_, int_, int4_, serial_, serial4_, bingint_, int8_, bigserial_, serial8_, float4_, real_, float8_, double_precision_, text_, varchar_, bytea_, timestamp_, timestamp_without_time_zone_, timestamptz_, timestamp_with_time_zone_, date_, time_, json_, jsonb_, uuid_, inet_, macaddr_)
+    VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29, $30, $31, $32, $33, $34, $35, $36, $37);
+
+",
+                )?;
+            client
+                .execute(
+                    &stmt,
+                    &[
+                        custom_domain_,
+                        custom_array_,
+                        domain_,
+                        array_,
+                        bool_,
+                        boolean_,
+                        char_,
+                        smallint_,
+                        int2_,
+                        smallserial_,
+                        serial2_,
+                        int_,
+                        int4_,
+                        serial_,
+                        serial4_,
+                        bingint_,
+                        int8_,
+                        bigserial_,
+                        serial8_,
+                        float4_,
+                        real_,
+                        float8_,
+                        double_precision_,
+                        text_,
+                        varchar_,
+                        bytea_,
+                        timestamp_,
+                        timestamp_without_time_zone_,
+                        timestamptz_,
+                        timestamp_with_time_zone_,
+                        date_,
+                        time_,
+                        json_,
+                        jsonb_,
+                        uuid_,
+                        inet_,
+                        macaddr_,
+                    ],
+                )
         }
     }
     pub mod module_1 {
@@ -984,35 +970,17 @@ FROM
             pub fn query<C: GenericClient>(
                 &'a self,
                 client: &'a mut C,
-            ) -> InsertBookQuery<'a, C> {
+            ) -> Result<u64, postgres::Error> {
                 insert_book(client, &self.book_name)
-            }
-        }
-        pub struct InsertBookQuery<'a, C: GenericClient> {
-            client: &'a mut C,
-            params: [&'a (dyn postgres_types::ToSql + Sync); 1],
-        }
-        impl<'a, C> InsertBookQuery<'a, C>
-        where
-            C: GenericClient,
-        {
-            pub fn stmt(&mut self) -> Result<postgres::Statement, postgres::Error> {
-                self.client.prepare("INSERT INTO Book (title)
-  VALUES ($1);")
-            }
-            pub fn exec(mut self) -> Result<u64, postgres::Error> {
-                let stmt = self.stmt()?;
-                self.client.execute(&stmt, &self.params)
             }
         }
         pub fn insert_book<'a, C: GenericClient>(
             client: &'a mut C,
             book_name: &'a &str,
-        ) -> InsertBookQuery<'a, C> {
-            InsertBookQuery {
-                client,
-                params: [book_name],
-            }
+        ) -> Result<u64, postgres::Error> {
+            let stmt = client.prepare("INSERT INTO Book (title)
+  VALUES ($1);")?;
+            client.execute(&stmt, &[book_name])
         }
         pub struct NightmareBorrowed<'a> {
             pub composite: super::super::types::public::NightmareCompositeBorrowed<'a>,

--- a/src/integration/cornucopia.rs
+++ b/src/integration/cornucopia.rs
@@ -124,105 +124,6 @@ pub mod types {
                 }
             }
         }
-        #[derive(Debug, postgres_types::ToSql, Clone, PartialEq)]
-        #[postgres(name = "nightmare_composite")]
-        pub struct NightmareComposite {
-            pub custom: Vec<super::super::types::public::CustomComposite>,
-            pub spongebob: Vec<super::super::types::public::SpongebobCharacter>,
-        }
-        impl<'a> postgres_types::FromSql<'a> for NightmareComposite {
-            fn from_sql(
-                _type: &postgres_types::Type,
-                buf: &'a [u8],
-            ) -> std::result::Result<
-                    NightmareComposite,
-                    std::boxed::Box<
-                        dyn std::error::Error + std::marker::Sync + std::marker::Send,
-                    >,
-                > {
-                let fields = match *_type.kind() {
-                    postgres_types::Kind::Composite(ref fields) => fields,
-                    _ => unreachable!(),
-                };
-                let mut buf = buf;
-                let num_fields = postgres_types::private::read_be_i32(&mut buf)?;
-                let _oid = postgres_types::private::read_be_i32(&mut buf)?;
-                let custom = postgres_types::private::read_value(
-                    fields[0].type_(),
-                    &mut buf,
-                )?;
-                let _oid = postgres_types::private::read_be_i32(&mut buf)?;
-                let spongebob = postgres_types::private::read_value(
-                    fields[1].type_(),
-                    &mut buf,
-                )?;
-                std::result::Result::Ok(NightmareComposite {
-                    custom,
-                    spongebob,
-                })
-            }
-            fn accepts(type_: &postgres_types::Type) -> bool {
-                type_.name() == "nightmare_composite" && type_.schema() == "public"
-            }
-        }
-        pub struct NightmareCompositeBorrowed<'a> {
-            pub custom: cornucopia_client::ArrayIterator<
-                'a,
-                super::super::types::public::CustomCompositeBorrowed<'a>,
-            >,
-            pub spongebob: cornucopia_client::ArrayIterator<
-                'a,
-                super::super::types::public::SpongebobCharacter,
-            >,
-        }
-        impl<'a> postgres_types::FromSql<'a> for NightmareCompositeBorrowed<'a> {
-            fn from_sql(
-                _type: &postgres_types::Type,
-                buf: &'a [u8],
-            ) -> std::result::Result<
-                    NightmareCompositeBorrowed<'a>,
-                    std::boxed::Box<
-                        dyn std::error::Error + std::marker::Sync + std::marker::Send,
-                    >,
-                > {
-                let fields = match *_type.kind() {
-                    postgres_types::Kind::Composite(ref fields) => fields,
-                    _ => unreachable!(),
-                };
-                let mut buf = buf;
-                let num_fields = postgres_types::private::read_be_i32(&mut buf)?;
-                let _oid = postgres_types::private::read_be_i32(&mut buf)?;
-                let custom = postgres_types::private::read_value(
-                    fields[0].type_(),
-                    &mut buf,
-                )?;
-                let _oid = postgres_types::private::read_be_i32(&mut buf)?;
-                let spongebob = postgres_types::private::read_value(
-                    fields[1].type_(),
-                    &mut buf,
-                )?;
-                std::result::Result::Ok(NightmareCompositeBorrowed {
-                    custom,
-                    spongebob,
-                })
-            }
-            fn accepts(type_: &postgres_types::Type) -> bool {
-                type_.name() == "nightmare_composite" && type_.schema() == "public"
-            }
-        }
-        impl<'a> From<NightmareCompositeBorrowed<'a>> for NightmareComposite {
-            fn from(
-                NightmareCompositeBorrowed {
-                    custom,
-                    spongebob,
-                }: NightmareCompositeBorrowed<'a>,
-            ) -> Self {
-                Self {
-                    custom: custom.map(|v| v.into()).collect(),
-                    spongebob: spongebob.map(|v| v.into()).collect(),
-                }
-            }
-        }
         #[derive(Debug, Clone, PartialEq, postgres_types::ToSql)]
         #[postgres(name = "custom_domain")]
         pub struct CustomDomain(pub Vec<super::super::types::public::CustomComposite>);
@@ -346,174 +247,118 @@ pub mod types {
                 Self(inner.into())
             }
         }
+        #[derive(Debug, postgres_types::ToSql, Clone, PartialEq)]
+        #[postgres(name = "nightmare_composite")]
+        pub struct NightmareComposite {
+            pub custom: Vec<super::super::types::public::CustomComposite>,
+            pub spongebob: Vec<super::super::types::public::SpongebobCharacter>,
+        }
+        impl<'a> postgres_types::FromSql<'a> for NightmareComposite {
+            fn from_sql(
+                _type: &postgres_types::Type,
+                buf: &'a [u8],
+            ) -> std::result::Result<
+                    NightmareComposite,
+                    std::boxed::Box<
+                        dyn std::error::Error + std::marker::Sync + std::marker::Send,
+                    >,
+                > {
+                let fields = match *_type.kind() {
+                    postgres_types::Kind::Composite(ref fields) => fields,
+                    _ => unreachable!(),
+                };
+                let mut buf = buf;
+                let num_fields = postgres_types::private::read_be_i32(&mut buf)?;
+                let _oid = postgres_types::private::read_be_i32(&mut buf)?;
+                let custom = postgres_types::private::read_value(
+                    fields[0].type_(),
+                    &mut buf,
+                )?;
+                let _oid = postgres_types::private::read_be_i32(&mut buf)?;
+                let spongebob = postgres_types::private::read_value(
+                    fields[1].type_(),
+                    &mut buf,
+                )?;
+                std::result::Result::Ok(NightmareComposite {
+                    custom,
+                    spongebob,
+                })
+            }
+            fn accepts(type_: &postgres_types::Type) -> bool {
+                type_.name() == "nightmare_composite" && type_.schema() == "public"
+            }
+        }
+        pub struct NightmareCompositeBorrowed<'a> {
+            pub custom: cornucopia_client::ArrayIterator<
+                'a,
+                super::super::types::public::CustomCompositeBorrowed<'a>,
+            >,
+            pub spongebob: cornucopia_client::ArrayIterator<
+                'a,
+                super::super::types::public::SpongebobCharacter,
+            >,
+        }
+        impl<'a> postgres_types::FromSql<'a> for NightmareCompositeBorrowed<'a> {
+            fn from_sql(
+                _type: &postgres_types::Type,
+                buf: &'a [u8],
+            ) -> std::result::Result<
+                    NightmareCompositeBorrowed<'a>,
+                    std::boxed::Box<
+                        dyn std::error::Error + std::marker::Sync + std::marker::Send,
+                    >,
+                > {
+                let fields = match *_type.kind() {
+                    postgres_types::Kind::Composite(ref fields) => fields,
+                    _ => unreachable!(),
+                };
+                let mut buf = buf;
+                let num_fields = postgres_types::private::read_be_i32(&mut buf)?;
+                let _oid = postgres_types::private::read_be_i32(&mut buf)?;
+                let custom = postgres_types::private::read_value(
+                    fields[0].type_(),
+                    &mut buf,
+                )?;
+                let _oid = postgres_types::private::read_be_i32(&mut buf)?;
+                let spongebob = postgres_types::private::read_value(
+                    fields[1].type_(),
+                    &mut buf,
+                )?;
+                std::result::Result::Ok(NightmareCompositeBorrowed {
+                    custom,
+                    spongebob,
+                })
+            }
+            fn accepts(type_: &postgres_types::Type) -> bool {
+                type_.name() == "nightmare_composite" && type_.schema() == "public"
+            }
+        }
+        impl<'a> From<NightmareCompositeBorrowed<'a>> for NightmareComposite {
+            fn from(
+                NightmareCompositeBorrowed {
+                    custom,
+                    spongebob,
+                }: NightmareCompositeBorrowed<'a>,
+            ) -> Self {
+                Self {
+                    custom: custom.map(|v| v.into()).collect(),
+                    spongebob: spongebob.map(|v| v.into()).collect(),
+                }
+            }
+        }
     }
 }
 pub mod queries {
-    pub mod module_1 {
-        use futures::{StreamExt, TryStreamExt};
-        pub struct InsertBookParams<'a> {
-            pub book_name: &'a str,
-        }
-        impl<'a> InsertBookParams<'a> {
-            pub fn query<C: cornucopia_client::GenericClient>(
-                &'a self,
-                client: &'a C,
-            ) -> InsertBookQuery<'a, C> {
-                insert_book(client, &self.book_name)
-            }
-        }
-        pub struct InsertBookQuery<'a, C: cornucopia_client::GenericClient> {
-            client: &'a C,
-            params: [&'a (dyn tokio_postgres::types::ToSql + Sync); 1],
-        }
-        impl<'a, C> InsertBookQuery<'a, C>
-        where
-            C: cornucopia_client::GenericClient,
-        {
-            pub async fn stmt(
-                &self,
-            ) -> Result<tokio_postgres::Statement, tokio_postgres::Error> {
-                self.client.prepare("INSERT INTO Book (title)
-  VALUES ($1);").await
-            }
-            pub async fn exec(self) -> Result<u64, tokio_postgres::Error> {
-                let stmt = self.stmt().await?;
-                self.client.execute(&stmt, &self.params).await
-            }
-        }
-        pub fn insert_book<'a, C: cornucopia_client::GenericClient>(
-            client: &'a C,
-            book_name: &'a &str,
-        ) -> InsertBookQuery<'a, C> {
-            InsertBookQuery {
-                client,
-                params: [book_name],
-            }
-        }
-        pub struct NightmareBorrowed<'a> {
-            pub composite: super::super::types::public::NightmareCompositeBorrowed<'a>,
-            pub name: &'a str,
-            pub names: cornucopia_client::ArrayIterator<'a, &'a str>,
-            pub data: Option<&'a [u8]>,
-            pub datas: Option<cornucopia_client::ArrayIterator<'a, &'a [u8]>>,
-        }
-        #[derive(Debug, Clone, PartialEq)]
-        pub struct Nightmare {
-            pub composite: super::super::types::public::NightmareComposite,
-            pub name: String,
-            pub names: Vec<String>,
-            pub data: Option<Vec<u8>>,
-            pub datas: Option<Vec<Vec<u8>>>,
-        }
-        impl<'a> From<NightmareBorrowed<'a>> for Nightmare {
-            fn from(
-                NightmareBorrowed {
-                    composite,
-                    name,
-                    names,
-                    data,
-                    datas,
-                }: NightmareBorrowed<'a>,
-            ) -> Self {
-                Self {
-                    composite: composite.into(),
-                    name: name.into(),
-                    names: names.map(|v| v.into()).collect(),
-                    data: data.map(|v| v.into()),
-                    datas: datas.map(|v| v.map(|v| v.into()).collect()),
-                }
-            }
-        }
-        pub struct NightmareQuery<'a, C: cornucopia_client::GenericClient, T> {
-            client: &'a C,
-            params: [&'a (dyn tokio_postgres::types::ToSql + Sync); 0],
-            mapper: fn(NightmareBorrowed) -> T,
-        }
-        impl<'a, C, T> NightmareQuery<'a, C, T>
-        where
-            C: cornucopia_client::GenericClient,
-        {
-            pub fn map<R>(
-                self,
-                mapper: fn(NightmareBorrowed) -> R,
-            ) -> NightmareQuery<'a, C, R> {
-                NightmareQuery {
-                    client: self.client,
-                    params: self.params,
-                    mapper,
-                }
-            }
-            pub fn extractor(row: &tokio_postgres::row::Row) -> NightmareBorrowed {
-                NightmareBorrowed {
-                    composite: row.get(0),
-                    name: row.get(1),
-                    names: row.get(2),
-                    data: row.get(3),
-                    datas: row.get(4),
-                }
-            }
-            pub async fn stmt(
-                &self,
-            ) -> Result<tokio_postgres::Statement, tokio_postgres::Error> {
-                self.client.prepare("SELECT
-  *
-FROM
-  nightmare;
-
-").await
-            }
-            pub async fn one(self) -> Result<T, tokio_postgres::Error> {
-                let stmt = self.stmt().await?;
-                let row = self.client.query_one(&stmt, &self.params).await?;
-                Ok((self.mapper)(Self::extractor(&row)))
-            }
-            pub async fn vec(self) -> Result<Vec<T>, tokio_postgres::Error> {
-                self.stream().await?.try_collect().await
-            }
-            pub async fn opt(self) -> Result<Option<T>, tokio_postgres::Error> {
-                let stmt = self.stmt().await?;
-                Ok(
-                    self
-                        .client
-                        .query_opt(&stmt, &self.params)
-                        .await?
-                        .map(|row| (self.mapper)(Self::extractor(&row))),
-                )
-            }
-            pub async fn stream(
-                self,
-            ) -> Result<
-                    impl futures::Stream<Item = Result<T, tokio_postgres::Error>>,
-                    tokio_postgres::Error,
-                > {
-                let stmt = self.stmt().await?;
-                let stream = self
-                    .client
-                    .query_raw(&stmt, cornucopia_client::slice_iter(&self.params))
-                    .await?
-                    .map(move |res| res.map(|row| (self.mapper)(Self::extractor(&row))));
-                Ok(stream.into_stream())
-            }
-        }
-        pub fn nightmare<'a, C: cornucopia_client::GenericClient>(
-            client: &'a C,
-        ) -> NightmareQuery<'a, C, Nightmare> {
-            NightmareQuery {
-                client,
-                params: [],
-                mapper: |it| Nightmare::from(it),
-            }
-        }
-    }
     pub mod module_2 {
-        use futures::{StreamExt, TryStreamExt};
+        use postgres::fallible_iterator::FallibleIterator;
+        use postgres::GenericClient;
         pub struct AuthorNameStartingWithParams<'a> {
             pub start_str: &'a str,
         }
         impl<'a> AuthorNameStartingWithParams<'a> {
-            pub fn query<C: cornucopia_client::GenericClient>(
+            pub fn query<C: GenericClient>(
                 &'a self,
-                client: &'a C,
+                client: &'a mut C,
             ) -> AuthorNameStartingWithQuery<'a, C, AuthorNameStartingWith> {
                 author_name_starting_with(client, &self.start_str)
             }
@@ -534,18 +379,14 @@ FROM
                 Self { name: name.into() }
             }
         }
-        pub struct AuthorNameStartingWithQuery<
-            'a,
-            C: cornucopia_client::GenericClient,
-            T,
-        > {
-            client: &'a C,
-            params: [&'a (dyn tokio_postgres::types::ToSql + Sync); 1],
+        pub struct AuthorNameStartingWithQuery<'a, C: GenericClient, T> {
+            client: &'a mut C,
+            params: [&'a (dyn postgres_types::ToSql + Sync); 1],
             mapper: fn(AuthorNameStartingWithBorrowed) -> T,
         }
-        impl<'a, C, T> AuthorNameStartingWithQuery<'a, C, T>
+        impl<'a, C, T: 'a> AuthorNameStartingWithQuery<'a, C, T>
         where
-            C: cornucopia_client::GenericClient,
+            C: GenericClient,
         {
             pub fn map<R>(
                 self,
@@ -558,15 +399,13 @@ FROM
                 }
             }
             pub fn extractor(
-                row: &tokio_postgres::row::Row,
+                row: &postgres::row::Row,
             ) -> AuthorNameStartingWithBorrowed {
                 AuthorNameStartingWithBorrowed {
                     name: row.get(0),
                 }
             }
-            pub async fn stmt(
-                &self,
-            ) -> Result<tokio_postgres::Statement, tokio_postgres::Error> {
+            pub fn stmt(&mut self) -> Result<postgres::Statement, postgres::Error> {
                 self.client
                     .prepare(
                         "SELECT
@@ -576,43 +415,41 @@ FROM
 WHERE
     name LIKE CONCAT($1::text, '%');",
                     )
-                    .await
             }
-            pub async fn one(self) -> Result<T, tokio_postgres::Error> {
-                let stmt = self.stmt().await?;
-                let row = self.client.query_one(&stmt, &self.params).await?;
+            pub fn one(mut self) -> Result<T, postgres::Error> {
+                let stmt = self.stmt()?;
+                let row = self.client.query_one(&stmt, &self.params)?;
                 Ok((self.mapper)(Self::extractor(&row)))
             }
-            pub async fn vec(self) -> Result<Vec<T>, tokio_postgres::Error> {
-                self.stream().await?.try_collect().await
+            pub fn vec(self) -> Result<Vec<T>, postgres::Error> {
+                self.stream()?.collect()
             }
-            pub async fn opt(self) -> Result<Option<T>, tokio_postgres::Error> {
-                let stmt = self.stmt().await?;
+            pub fn opt(mut self) -> Result<Option<T>, postgres::Error> {
+                let stmt = self.stmt()?;
                 Ok(
                     self
                         .client
-                        .query_opt(&stmt, &self.params)
-                        .await?
+                        .query_opt(&stmt, &self.params)?
                         .map(|row| (self.mapper)(Self::extractor(&row))),
                 )
             }
-            pub async fn stream(
-                self,
+            pub fn stream(
+                mut self,
             ) -> Result<
-                    impl futures::Stream<Item = Result<T, tokio_postgres::Error>>,
-                    tokio_postgres::Error,
+                    impl Iterator<Item = Result<T, postgres::Error>> + 'a,
+                    postgres::Error,
                 > {
-                let stmt = self.stmt().await?;
+                let stmt = self.stmt()?;
                 let stream = self
                     .client
-                    .query_raw(&stmt, cornucopia_client::slice_iter(&self.params))
-                    .await?
+                    .query_raw(&stmt, cornucopia_client::slice_iter(&self.params))?
+                    .iterator()
                     .map(move |res| res.map(|row| (self.mapper)(Self::extractor(&row))));
-                Ok(stream.into_stream())
+                Ok(stream)
             }
         }
-        pub fn author_name_starting_with<'a, C: cornucopia_client::GenericClient>(
-            client: &'a C,
+        pub fn author_name_starting_with<'a, C: GenericClient>(
+            client: &'a mut C,
             start_str: &'a &str,
         ) -> AuthorNameStartingWithQuery<'a, C, AuthorNameStartingWith> {
             AuthorNameStartingWithQuery {
@@ -661,8 +498,8 @@ WHERE
             pub timestamp_with_time_zone_: time::OffsetDateTime,
             pub date_: time::Date,
             pub time_: time::Time,
-            pub json_: tokio_postgres::types::Json<&'a serde_json::value::RawValue>,
-            pub jsonb_: tokio_postgres::types::Json<&'a serde_json::value::RawValue>,
+            pub json_: postgres_types::Json<&'a serde_json::value::RawValue>,
+            pub jsonb_: postgres_types::Json<&'a serde_json::value::RawValue>,
             pub uuid_: uuid::Uuid,
             pub inet_: std::net::IpAddr,
             pub macaddr_: eui48::MacAddress,
@@ -702,8 +539,8 @@ WHERE
             pub timestamp_with_time_zone_: time::OffsetDateTime,
             pub date_: time::Date,
             pub time_: time::Time,
-            pub json_: tokio_postgres::types::Json<serde_json::Value>,
-            pub jsonb_: tokio_postgres::types::Json<serde_json::Value>,
+            pub json_: postgres_types::Json<serde_json::Value>,
+            pub jsonb_: postgres_types::Json<serde_json::Value>,
             pub uuid_: uuid::Uuid,
             pub inet_: std::net::IpAddr,
             pub macaddr_: eui48::MacAddress,
@@ -785,10 +622,10 @@ WHERE
                     timestamp_with_time_zone_,
                     date_,
                     time_,
-                    json_: tokio_postgres::types::Json(
+                    json_: postgres_types::Json(
                         serde_json::from_str(json_.0.get()).unwrap(),
                     ),
-                    jsonb_: tokio_postgres::types::Json(
+                    jsonb_: postgres_types::Json(
                         serde_json::from_str(jsonb_.0.get()).unwrap(),
                     ),
                     uuid_,
@@ -797,14 +634,14 @@ WHERE
                 }
             }
         }
-        pub struct SelectEverythingQuery<'a, C: cornucopia_client::GenericClient, T> {
-            client: &'a C,
-            params: [&'a (dyn tokio_postgres::types::ToSql + Sync); 0],
+        pub struct SelectEverythingQuery<'a, C: GenericClient, T> {
+            client: &'a mut C,
+            params: [&'a (dyn postgres_types::ToSql + Sync); 0],
             mapper: fn(SelectEverythingBorrowed) -> T,
         }
-        impl<'a, C, T> SelectEverythingQuery<'a, C, T>
+        impl<'a, C, T: 'a> SelectEverythingQuery<'a, C, T>
         where
-            C: cornucopia_client::GenericClient,
+            C: GenericClient,
         {
             pub fn map<R>(
                 self,
@@ -816,9 +653,7 @@ WHERE
                     mapper,
                 }
             }
-            pub fn extractor(
-                row: &tokio_postgres::row::Row,
-            ) -> SelectEverythingBorrowed {
+            pub fn extractor(row: &postgres::row::Row) -> SelectEverythingBorrowed {
                 SelectEverythingBorrowed {
                     custom_domain_: row.get(0),
                     custom_array_: row.get(1),
@@ -860,9 +695,7 @@ WHERE
                     macaddr_: row.get(37),
                 }
             }
-            pub async fn stmt(
-                &self,
-            ) -> Result<tokio_postgres::Statement, tokio_postgres::Error> {
+            pub fn stmt(&mut self) -> Result<postgres::Statement, postgres::Error> {
                 self.client
                     .prepare(
                         "SELECT
@@ -907,43 +740,41 @@ WHERE
 FROM
     Everything;",
                     )
-                    .await
             }
-            pub async fn one(self) -> Result<T, tokio_postgres::Error> {
-                let stmt = self.stmt().await?;
-                let row = self.client.query_one(&stmt, &self.params).await?;
+            pub fn one(mut self) -> Result<T, postgres::Error> {
+                let stmt = self.stmt()?;
+                let row = self.client.query_one(&stmt, &self.params)?;
                 Ok((self.mapper)(Self::extractor(&row)))
             }
-            pub async fn vec(self) -> Result<Vec<T>, tokio_postgres::Error> {
-                self.stream().await?.try_collect().await
+            pub fn vec(self) -> Result<Vec<T>, postgres::Error> {
+                self.stream()?.collect()
             }
-            pub async fn opt(self) -> Result<Option<T>, tokio_postgres::Error> {
-                let stmt = self.stmt().await?;
+            pub fn opt(mut self) -> Result<Option<T>, postgres::Error> {
+                let stmt = self.stmt()?;
                 Ok(
                     self
                         .client
-                        .query_opt(&stmt, &self.params)
-                        .await?
+                        .query_opt(&stmt, &self.params)?
                         .map(|row| (self.mapper)(Self::extractor(&row))),
                 )
             }
-            pub async fn stream(
-                self,
+            pub fn stream(
+                mut self,
             ) -> Result<
-                    impl futures::Stream<Item = Result<T, tokio_postgres::Error>>,
-                    tokio_postgres::Error,
+                    impl Iterator<Item = Result<T, postgres::Error>> + 'a,
+                    postgres::Error,
                 > {
-                let stmt = self.stmt().await?;
+                let stmt = self.stmt()?;
                 let stream = self
                     .client
-                    .query_raw(&stmt, cornucopia_client::slice_iter(&self.params))
-                    .await?
+                    .query_raw(&stmt, cornucopia_client::slice_iter(&self.params))?
+                    .iterator()
                     .map(move |res| res.map(|row| (self.mapper)(Self::extractor(&row))));
-                Ok(stream.into_stream())
+                Ok(stream)
             }
         }
-        pub fn select_everything<'a, C: cornucopia_client::GenericClient>(
-            client: &'a C,
+        pub fn select_everything<'a, C: GenericClient>(
+            client: &'a mut C,
         ) -> SelectEverythingQuery<'a, C, SelectEverything> {
             SelectEverythingQuery {
                 client,
@@ -984,16 +815,16 @@ FROM
             pub timestamp_with_time_zone_: time::OffsetDateTime,
             pub date_: time::Date,
             pub time_: time::Time,
-            pub json_: tokio_postgres::types::Json<&'a serde_json::value::RawValue>,
-            pub jsonb_: tokio_postgres::types::Json<&'a serde_json::value::RawValue>,
+            pub json_: postgres_types::Json<&'a serde_json::value::RawValue>,
+            pub jsonb_: postgres_types::Json<&'a serde_json::value::RawValue>,
             pub uuid_: uuid::Uuid,
             pub inet_: std::net::IpAddr,
             pub macaddr_: eui48::MacAddress,
         }
         impl<'a> InsertEverythingParams<'a> {
-            pub fn query<C: cornucopia_client::GenericClient>(
+            pub fn query<C: GenericClient>(
                 &'a self,
-                client: &'a C,
+                client: &'a mut C,
             ) -> InsertEverythingQuery<'a, C> {
                 insert_everything(
                     client,
@@ -1037,17 +868,15 @@ FROM
                 )
             }
         }
-        pub struct InsertEverythingQuery<'a, C: cornucopia_client::GenericClient> {
-            client: &'a C,
-            params: [&'a (dyn tokio_postgres::types::ToSql + Sync); 37],
+        pub struct InsertEverythingQuery<'a, C: GenericClient> {
+            client: &'a mut C,
+            params: [&'a (dyn postgres_types::ToSql + Sync); 37],
         }
         impl<'a, C> InsertEverythingQuery<'a, C>
         where
-            C: cornucopia_client::GenericClient,
+            C: GenericClient,
         {
-            pub async fn stmt(
-                &self,
-            ) -> Result<tokio_postgres::Statement, tokio_postgres::Error> {
+            pub fn stmt(&mut self) -> Result<postgres::Statement, postgres::Error> {
                 self.client
                     .prepare(
                         "INSERT INTO Everything (custom_domain_, custom_array_, domain_, array_, bool_, boolean_, char_, smallint_, int2_, smallserial_, serial2_, int_, int4_, serial_, serial4_, bingint_, int8_, bigserial_, serial8_, float4_, real_, float8_, double_precision_, text_, varchar_, bytea_, timestamp_, timestamp_without_time_zone_, timestamptz_, timestamp_with_time_zone_, date_, time_, json_, jsonb_, uuid_, inet_, macaddr_)
@@ -1055,15 +884,14 @@ FROM
 
 ",
                     )
-                    .await
             }
-            pub async fn exec(self) -> Result<u64, tokio_postgres::Error> {
-                let stmt = self.stmt().await?;
-                self.client.execute(&stmt, &self.params).await
+            pub fn exec(mut self) -> Result<u64, postgres::Error> {
+                let stmt = self.stmt()?;
+                self.client.execute(&stmt, &self.params)
             }
         }
-        pub fn insert_everything<'a, C: cornucopia_client::GenericClient>(
-            client: &'a C,
+        pub fn insert_everything<'a, C: GenericClient>(
+            client: &'a mut C,
             custom_domain_: &'a super::super::types::public::CustomDomain,
             custom_array_: &'a &'a [super::super::types::public::SpongebobCharacter],
             domain_: &'a super::super::types::public::MyDomain,
@@ -1096,8 +924,8 @@ FROM
             timestamp_with_time_zone_: &'a time::OffsetDateTime,
             date_: &'a time::Date,
             time_: &'a time::Time,
-            json_: &'a tokio_postgres::types::Json<&serde_json::value::RawValue>,
-            jsonb_: &'a tokio_postgres::types::Json<&serde_json::value::RawValue>,
+            json_: &'a postgres_types::Json<&serde_json::value::RawValue>,
+            jsonb_: &'a postgres_types::Json<&serde_json::value::RawValue>,
             uuid_: &'a uuid::Uuid,
             inet_: &'a std::net::IpAddr,
             macaddr_: &'a eui48::MacAddress,
@@ -1143,6 +971,158 @@ FROM
                     inet_,
                     macaddr_,
                 ],
+            }
+        }
+    }
+    pub mod module_1 {
+        use postgres::fallible_iterator::FallibleIterator;
+        use postgres::GenericClient;
+        pub struct InsertBookParams<'a> {
+            pub book_name: &'a str,
+        }
+        impl<'a> InsertBookParams<'a> {
+            pub fn query<C: GenericClient>(
+                &'a self,
+                client: &'a mut C,
+            ) -> InsertBookQuery<'a, C> {
+                insert_book(client, &self.book_name)
+            }
+        }
+        pub struct InsertBookQuery<'a, C: GenericClient> {
+            client: &'a mut C,
+            params: [&'a (dyn postgres_types::ToSql + Sync); 1],
+        }
+        impl<'a, C> InsertBookQuery<'a, C>
+        where
+            C: GenericClient,
+        {
+            pub fn stmt(&mut self) -> Result<postgres::Statement, postgres::Error> {
+                self.client.prepare("INSERT INTO Book (title)
+  VALUES ($1);")
+            }
+            pub fn exec(mut self) -> Result<u64, postgres::Error> {
+                let stmt = self.stmt()?;
+                self.client.execute(&stmt, &self.params)
+            }
+        }
+        pub fn insert_book<'a, C: GenericClient>(
+            client: &'a mut C,
+            book_name: &'a &str,
+        ) -> InsertBookQuery<'a, C> {
+            InsertBookQuery {
+                client,
+                params: [book_name],
+            }
+        }
+        pub struct NightmareBorrowed<'a> {
+            pub composite: super::super::types::public::NightmareCompositeBorrowed<'a>,
+            pub name: &'a str,
+            pub names: cornucopia_client::ArrayIterator<'a, &'a str>,
+            pub data: Option<&'a [u8]>,
+            pub datas: Option<cornucopia_client::ArrayIterator<'a, &'a [u8]>>,
+        }
+        #[derive(Debug, Clone, PartialEq)]
+        pub struct Nightmare {
+            pub composite: super::super::types::public::NightmareComposite,
+            pub name: String,
+            pub names: Vec<String>,
+            pub data: Option<Vec<u8>>,
+            pub datas: Option<Vec<Vec<u8>>>,
+        }
+        impl<'a> From<NightmareBorrowed<'a>> for Nightmare {
+            fn from(
+                NightmareBorrowed {
+                    composite,
+                    name,
+                    names,
+                    data,
+                    datas,
+                }: NightmareBorrowed<'a>,
+            ) -> Self {
+                Self {
+                    composite: composite.into(),
+                    name: name.into(),
+                    names: names.map(|v| v.into()).collect(),
+                    data: data.map(|v| v.into()),
+                    datas: datas.map(|v| v.map(|v| v.into()).collect()),
+                }
+            }
+        }
+        pub struct NightmareQuery<'a, C: GenericClient, T> {
+            client: &'a mut C,
+            params: [&'a (dyn postgres_types::ToSql + Sync); 0],
+            mapper: fn(NightmareBorrowed) -> T,
+        }
+        impl<'a, C, T: 'a> NightmareQuery<'a, C, T>
+        where
+            C: GenericClient,
+        {
+            pub fn map<R>(
+                self,
+                mapper: fn(NightmareBorrowed) -> R,
+            ) -> NightmareQuery<'a, C, R> {
+                NightmareQuery {
+                    client: self.client,
+                    params: self.params,
+                    mapper,
+                }
+            }
+            pub fn extractor(row: &postgres::row::Row) -> NightmareBorrowed {
+                NightmareBorrowed {
+                    composite: row.get(0),
+                    name: row.get(1),
+                    names: row.get(2),
+                    data: row.get(3),
+                    datas: row.get(4),
+                }
+            }
+            pub fn stmt(&mut self) -> Result<postgres::Statement, postgres::Error> {
+                self.client.prepare("SELECT
+  *
+FROM
+  nightmare;
+
+")
+            }
+            pub fn one(mut self) -> Result<T, postgres::Error> {
+                let stmt = self.stmt()?;
+                let row = self.client.query_one(&stmt, &self.params)?;
+                Ok((self.mapper)(Self::extractor(&row)))
+            }
+            pub fn vec(self) -> Result<Vec<T>, postgres::Error> {
+                self.stream()?.collect()
+            }
+            pub fn opt(mut self) -> Result<Option<T>, postgres::Error> {
+                let stmt = self.stmt()?;
+                Ok(
+                    self
+                        .client
+                        .query_opt(&stmt, &self.params)?
+                        .map(|row| (self.mapper)(Self::extractor(&row))),
+                )
+            }
+            pub fn stream(
+                mut self,
+            ) -> Result<
+                    impl Iterator<Item = Result<T, postgres::Error>> + 'a,
+                    postgres::Error,
+                > {
+                let stmt = self.stmt()?;
+                let stream = self
+                    .client
+                    .query_raw(&stmt, cornucopia_client::slice_iter(&self.params))?
+                    .iterator()
+                    .map(move |res| res.map(|row| (self.mapper)(Self::extractor(&row))));
+                Ok(stream)
+            }
+        }
+        pub fn nightmare<'a, C: GenericClient>(
+            client: &'a mut C,
+        ) -> NightmareQuery<'a, C, Nightmare> {
+            NightmareQuery {
+                client,
+                params: [],
+                mapper: |it| Nightmare::from(it),
             }
         }
     }

--- a/src/integration/migrations/1648515058_first.sql
+++ b/src/integration/migrations/1648515058_first.sql
@@ -11,7 +11,18 @@ CREATE TYPE custom_composite AS (
     nice spongebob_character
 );
 
+CREATE TYPE copy_composite AS (
+    first integer,
+    second float
+);
+
 CREATE DOMAIN my_domain AS TEXT CHECK (value ~ '^\w{5}$');
+CREATE DOMAIN copy_domain AS INTEGER CHECK (value > 42);
+
+CREATE TABLE Copy (
+    composite copy_composite,
+    domain copy_domain
+);
 
 CREATE DOMAIN custom_domain AS custom_composite[];
 

--- a/src/integration/queries/module_1.sql
+++ b/src/integration/queries/module_1.sql
@@ -8,3 +8,5 @@ SELECT
 FROM
   nightmare;
 
+--! copies
+SELECT * FROM copy;

--- a/src/integration/test.rs
+++ b/src/integration/test.rs
@@ -7,7 +7,7 @@ use postgres_types::Json;
 use serde_json::Map;
 use time::{OffsetDateTime, PrimitiveDateTime};
 use uuid::Uuid;
-
+/* 
 use self::error::Error;
 
 use crate::integration::cornucopia::{
@@ -185,3 +185,4 @@ mod error {
         Cornucopia(#[from] CornucopiaError),
     }
 }
+*/

--- a/src/integration/test.rs
+++ b/src/integration/test.rs
@@ -7,7 +7,7 @@ use postgres_types::Json;
 use serde_json::Map;
 use time::{OffsetDateTime, PrimitiveDateTime};
 use uuid::Uuid;
-/* 
+/*
 use self::error::Error;
 
 use crate::integration::cornucopia::{

--- a/src/integration/test.rs
+++ b/src/integration/test.rs
@@ -1,13 +1,14 @@
 use std::net::{IpAddr, Ipv4Addr};
 
-use error::Error;
+//use error::Error;
 use eui48::MacAddress;
-use futures::StreamExt;
+use postgres::Client;
 use postgres_types::Json;
 use serde_json::Map;
 use time::{OffsetDateTime, PrimitiveDateTime};
-use tokio_postgres::Client;
 use uuid::Uuid;
+
+use self::error::Error;
 
 use crate::integration::cornucopia::{
     self,
@@ -15,41 +16,41 @@ use crate::integration::cornucopia::{
     types::public::{CustomComposite, CustomDomain, MyDomain, SpongebobCharacter},
 };
 
-async fn setup() -> Result<Client, crate::error::Error> {
+fn setup() -> Result<Client, crate::error::Error> {
     use crate::run_migrations::run_migrations;
     use crate::{conn::cornucopia_conn, container};
 
     container::setup(true)?;
-    let client = cornucopia_conn().await?;
-    run_migrations(&client, "src/integration/migrations").await?;
+    let mut client = cornucopia_conn()?;
+    run_migrations(&mut client, "src/integration/migrations")?;
 
     Ok(client)
 }
 
-async fn teardown() -> Result<(), crate::error::Error> {
+fn teardown() -> Result<(), crate::error::Error> {
     use crate::container;
     container::cleanup(true)?;
     Ok(())
 }
 
-async fn integration() -> Result<(), Error> {
-    let client = setup().await?;
-    select_everything_test(&client).await?;
-    teardown().await?;
+fn integration() -> Result<(), Error> {
+    let mut client = setup()?;
+    select_everything_test(&mut client)?;
+    teardown()?;
 
     Ok(())
 }
 
-#[tokio::test]
+#[test]
 
-async fn integration_test() {
-    if let Err(e) = integration().await {
-        let _ = teardown().await;
+fn integration_test() {
+    if let Err(e) = integration() {
+        let _ = teardown();
         panic!("{:?}", e)
     }
 }
 
-async fn select_everything_test(client: &Client) -> Result<(), Error> {
+fn select_everything_test(client: &mut Client) -> Result<(), Error> {
     let primitive_datetime_format =
         time::format_description::parse("[year]-[month]-[day] [hour]:[minute]:[second]").unwrap();
     let primitive_datetime =
@@ -104,7 +105,7 @@ async fn select_everything_test(client: &Client) -> Result<(), Error> {
         macaddr_: MacAddress::new([8, 0, 43, 1, 2, 3]),
     };
 
-    assert_eq!(1, params.query(client).exec().await?, "inserting one row");
+    assert_eq!(1, params.query(client).exec()?, "inserting one row");
 
     let expected = SelectEverything {
         custom_domain_: vec![CustomComposite {
@@ -150,7 +151,7 @@ async fn select_everything_test(client: &Client) -> Result<(), Error> {
         inet_: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
         macaddr_: MacAddress::new([8, 0, 43, 1, 2, 3]),
     };
-    let actual = select_everything(client).one().await?;
+    let actual = select_everything(client).one()?;
 
     assert_eq!(expected, actual);
 
@@ -170,8 +171,8 @@ fn assert_eq<T: std::fmt::Debug + PartialEq>(expected: T, actual: T) -> Result<(
 
 mod error {
     use crate::error::Error as CornucopiaError;
+    use postgres::Error as DbError;
     use thiserror::Error as ThisError;
-    use tokio_postgres::Error as DbError;
     #[derive(Debug, ThisError)]
     #[error("error occured during integration testing")]
     pub(crate) enum Error {

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,9 +14,8 @@ pub(crate) mod type_registrar;
 use crate::cli::run;
 use crate::error::Error;
 
-#[tokio::main]
-async fn main() -> Result<(), Error> {
-    let result = run().await;
+fn main() -> Result<(), Error> {
+    let result = run();
     if let Err(e) = &result {
         eprintln!("{e}");
         std::process::exit(1);

--- a/src/prepare_queries.rs
+++ b/src/prepare_queries.rs
@@ -131,26 +131,25 @@ fn prepare_query(
         match &nullable_col.value {
             crate::parser::NullableColumn::Index(index) => {
                 // Get name from column index
-                let name = match stmt_cols.get(*index as usize - 1) {
-                    Some(col) => col.name(),
-                    None => {
-                        return Err(Error {
-                            err: ErrorVariant::Validation(
-                                ValidationError::InvalidNullableColumnIndex {
-                                    index: *index as usize,
-                                    max_col_index: stmt_cols.len(),
-                                    pos: ErrorPosition {
-                                        line: nullable_col.line,
-                                        col: nullable_col.col,
-                                        line_str: nullable_col.line_str,
-                                    },
+                let name = if let Some(col) = stmt_cols.get(*index as usize - 1) {
+                    col.name()
+                } else {
+                    return Err(Error {
+                        err: ErrorVariant::Validation(
+                            ValidationError::InvalidNullableColumnIndex {
+                                index: *index as usize,
+                                max_col_index: stmt_cols.len(),
+                                pos: ErrorPosition {
+                                    line: nullable_col.line,
+                                    col: nullable_col.col,
+                                    line_str: nullable_col.line_str,
                                 },
-                            ),
-                            query_name: query.name,
-                            query_start_line: Some(query.line),
-                            path: module_path.to_owned(),
-                        })
-                    }
+                            },
+                        ),
+                        query_name: query.name,
+                        query_start_line: Some(query.line),
+                        path: module_path.to_owned(),
+                    });
                 };
 
                 // Check if `nullable_cols` already contains this column. If not, add it.

--- a/src/prepare_queries.rs
+++ b/src/prepare_queries.rs
@@ -9,7 +9,7 @@ use crate::{
 };
 use error::Error;
 use error::ErrorVariant;
-use tokio_postgres::Client;
+use postgres::Client;
 
 /// This data structure is used by Cornucopia to generate all constructs related to this particular query.
 #[derive(Debug)]
@@ -58,27 +58,27 @@ where
 }
 
 /// Prepares all modules
-pub(crate) async fn prepare(
-    client: &Client,
+pub(crate) fn prepare(
+    client: &mut Client,
     type_registrar: &mut TypeRegistrar,
     modules: Vec<Module>,
 ) -> Result<Vec<PreparedModule>, Error> {
     let mut prepared_modules = Vec::new();
     for module in modules {
-        prepared_modules.push(prepare_module(client, module, type_registrar).await?);
+        prepared_modules.push(prepare_module(client, module, type_registrar)?);
     }
     Ok(prepared_modules)
 }
 
 /// Prepares all queries in this module
-async fn prepare_module(
-    client: &Client,
+fn prepare_module(
+    client: &mut Client,
     module: Module,
     type_registrar: &mut TypeRegistrar,
 ) -> Result<PreparedModule, Error> {
     let mut queries = Vec::new();
     for query in module.queries {
-        queries.push(prepare_query(client, type_registrar, query, &module.path).await?);
+        queries.push(prepare_query(client, type_registrar, query, &module.path)?);
     }
     Ok(PreparedModule {
         name: module.name,
@@ -87,8 +87,8 @@ async fn prepare_module(
 }
 
 /// Prepares a query
-async fn prepare_query(
-    client: &Client,
+fn prepare_query(
+    client: &mut Client,
     type_registrar: &mut TypeRegistrar,
     query: ParsedQuery,
     module_path: &str,
@@ -96,7 +96,6 @@ async fn prepare_query(
     // Prepare the statement
     let stmt = client
         .prepare(&query.sql_str)
-        .await
         .map_err(|e| Error::new(e, &query, module_path))?;
 
     // Get parameter parameters
@@ -105,7 +104,6 @@ async fn prepare_query(
         // Register type
         let ty = type_registrar
             .register(client, ty)
-            .await
             .map_err(|e| Error::new(e, &query, module_path))?;
         let name = name.value.to_owned();
         params.push(PreparedParameter {
@@ -222,7 +220,6 @@ async fn prepare_query(
     for column in stmt_cols {
         let ty = type_registrar
             .register(client, column.type_())
-            .await
             .map_err(|e| Error {
                 query_start_line: Some(query.line),
                 err: e.into(),
@@ -256,7 +253,7 @@ pub(crate) mod error {
     #[derive(Debug, ThisError)]
     #[error("{0}")]
     pub(crate) enum ErrorVariant {
-        Db(#[from] tokio_postgres::Error),
+        Db(#[from] postgres::Error),
         PostgresType(#[from] PostgresTypeError),
         Validation(#[from] ValidationError),
         #[error("Two or more columns have the same name: `{name}`. Consider disambiguing the column names with `AS` clauses.")]

--- a/src/run_migrations.rs
+++ b/src/run_migrations.rs
@@ -1,23 +1,20 @@
 use crate::read_migrations::read_migrations;
 use error::Error;
-use tokio_postgres::Client;
+use postgres::Client;
 
 /// Runs all migrations in the specified directory. Only `.sql` files are considered.
 ///
 /// # Errors
 /// Returns an error if a migration can't be read or installed.
-pub(crate) async fn run_migrations(client: &Client, dir_path: &str) -> Result<(), Error> {
+pub(crate) fn run_migrations(client: &mut Client, dir_path: &str) -> Result<(), Error> {
     // Create the table holding Cornucopia migrations
-    create_migration_table(client)
-        .await
-        .map_err(|err| Error::new(err.into(), None, dir_path))?;
+    create_migration_table(client).map_err(|err| Error::new(err.into(), None, dir_path))?;
 
     // Install each migration that is not already installed.
     for migration in
         read_migrations(dir_path).map_err(|err| Error::new(err.into(), None, dir_path))?
     {
         let migration_not_installed = !is_installed(client, &migration.timestamp, &migration.name)
-            .await
             .map_err(|err| Error::new(err.into(), None, &migration.path))?;
         if migration_not_installed {
             install_migration(
@@ -26,58 +23,52 @@ pub(crate) async fn run_migrations(client: &Client, dir_path: &str) -> Result<()
                 &migration.name,
                 &migration.sql,
             )
-            .await
             .map_err(|err| Error::new(err.into(), Some(&migration.sql), &migration.path))?;
         }
     }
     Ok(())
 }
 
-async fn create_migration_table(client: &Client) -> Result<(), tokio_postgres::Error> {
-    client
-        .execute(
-            "CREATE TABLE IF NOT EXISTS _cornucopia_migrations (
+fn create_migration_table(client: &mut Client) -> Result<(), postgres::Error> {
+    client.execute(
+        "CREATE TABLE IF NOT EXISTS _cornucopia_migrations (
     unix_timestamp BIGINT NOT NULL,
     name TEXT NOT NULL,
     installed_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     PRIMARY KEY (unix_timestamp, name)
 )",
-            &[],
-        )
-        .await?;
+        &[],
+    )?;
     Ok(())
 }
 
-async fn is_installed(
-    client: &Client,
+fn is_installed(
+    client: &mut Client,
     timestamp: &i64,
     name: &str,
-) -> Result<bool, tokio_postgres::Error> {
+) -> Result<bool, postgres::Error> {
     let is_installed: bool = client
         .query_one(
             "select EXISTS(
     SELECT 1 from _cornucopia_migrations 
     WHERE (unix_timestamp, name) = ($1, $2))",
             &[&timestamp, &name],
-        )
-        .await?
+        )?
         .get(0);
     Ok(is_installed)
 }
 
-async fn install_migration(
-    client: &Client,
+fn install_migration(
+    client: &mut Client,
     timestamp: &i64,
     name: &str,
     sql: &str,
-) -> Result<(), tokio_postgres::Error> {
-    client.batch_execute(sql).await?;
-    client
-        .execute(
-            "INSERT INTO _cornucopia_migrations VALUES ($1, $2)",
-            &[&timestamp, &name],
-        )
-        .await?;
+) -> Result<(), postgres::Error> {
+    client.batch_execute(sql)?;
+    client.execute(
+        "INSERT INTO _cornucopia_migrations VALUES ($1, $2)",
+        &[&timestamp, &name],
+    )?;
     Ok(())
 }
 
@@ -86,13 +77,13 @@ pub(crate) mod error {
 
     use super::super::read_migrations::error::Error as MigrationError;
     use thiserror::Error as ThisError;
-    use tokio_postgres::error::ErrorPosition;
+    use postgres::error::ErrorPosition;
 
     #[derive(Debug, ThisError)]
     #[error("{0}")]
     pub(crate) enum ErrorVariant {
         ReadMigration(#[from] MigrationError),
-        Db(#[from] tokio_postgres::Error),
+        Db(#[from] postgres::Error),
     }
 
     #[derive(Debug)]

--- a/src/run_migrations.rs
+++ b/src/run_migrations.rs
@@ -42,11 +42,7 @@ fn create_migration_table(client: &mut Client) -> Result<(), postgres::Error> {
     Ok(())
 }
 
-fn is_installed(
-    client: &mut Client,
-    timestamp: &i64,
-    name: &str,
-) -> Result<bool, postgres::Error> {
+fn is_installed(client: &mut Client, timestamp: &i64, name: &str) -> Result<bool, postgres::Error> {
     let is_installed: bool = client
         .query_one(
             "select EXISTS(
@@ -76,8 +72,8 @@ pub(crate) mod error {
     use std::{error::Error as ErrorTrait, fmt::Display};
 
     use super::super::read_migrations::error::Error as MigrationError;
-    use thiserror::Error as ThisError;
     use postgres::error::ErrorPosition;
+    use thiserror::Error as ThisError;
 
     #[derive(Debug, ThisError)]
     #[error("{0}")]

--- a/src/type_registrar.rs
+++ b/src/type_registrar.rs
@@ -47,8 +47,7 @@ impl CornucopiaType {
 
         if self.rust_path_from_queries == "postgres_types::Json<serde_json::Value>" {
             return format!(
-                "postgres_types::Json(serde_json::from_str({var_name}.0.get()).unwrap())
-            "
+                "postgres_types::Json(serde_json::from_str({var_name}.0.get()).unwrap())"
             );
         }
 


### PR DESCRIPTION
- Added support for `postgres` codegen in addition to `tokio-postgres` codegen.
- Removed all async from cornucopia
- No longer generates a query structure for execution and returns the number of modified rows 
- Small cleanups and simplifications

It's getting too big for a single PR, so I'll just clean up some things and call it a day for now. The current state of the codegen makes it difficult to implement the new features I've proposed in other issues, I'll try to improve it in other PRs.