### PR TITLE
Fix codegen and examples

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,7 +151,6 @@ dependencies = [
  "clap",
  "cornucopia_client",
  "eui48",
- "fallible-iterator",
  "heck",
  "indexmap",
  "pest",
@@ -197,9 +196,9 @@ version = "0.2.2"
 dependencies = [
  "async-trait",
  "deadpool-postgres",
- "fallible-iterator",
  "postgres",
  "postgres-protocol",
+ "postgres-types",
  "tokio",
  "tokio-postgres",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ members = ["examples/*", "cornucopia_client"]
 
 [dependencies]
 cornucopia_client = { path = "cornucopia_client" }
-fallible-iterator = "0.2.0"
 postgres = { version = "0.19.3", features = [
     "with-serde_json-1",
     "with-time-0_3",

--- a/README.md
+++ b/README.md
@@ -84,7 +84,6 @@ No special installation steps are needed for `podman`, but note that you will ne
 ### Dependencies
 #### Required
 * Client code: `cornucopia_client`.
-* Postgres type utils: `postgres_types`.
 
 #### (Optional) Async
 * Runtime: `tokio`.
@@ -109,7 +108,6 @@ The code block below shows what your dependencies might look like with every fea
 [dependencies]
 tokio = { version = "1.18.1", features = ["full"] }
 deadpool-postgres = { version = "0.10.2" }
-postgres-types = { version = "0.2.3", features = ["derive"] }
 cornucopia_client = "0.2.2"
 futures = "0.3.21"
 tokio-postgres = { version = "0.7.6", features = [

--- a/cornucopia_client/Cargo.toml
+++ b/cornucopia_client/Cargo.toml
@@ -14,9 +14,9 @@ keywords = ["postgresql", "query", "generator", "sql", "tokio-postgres"]
 
 [dependencies]
 tokio = { version = "1.18.1", features = ["full"] }
+postgres-types = { version = "0.2.3", features = ["derive"] }
 deadpool-postgres = "0.10.2"
 tokio-postgres = "0.7.6"
 postgres = "0.19.3"
 async-trait = "0.1.53"
-fallible-iterator = "0.2.0"
 postgres-protocol = "0.6.4"

--- a/cornucopia_client/src/lib.rs
+++ b/cornucopia_client/src/lib.rs
@@ -2,12 +2,14 @@ use std::marker::PhantomData;
 
 use async_trait::async_trait;
 use deadpool_postgres::{Client, ClientWrapper, Transaction};
-use fallible_iterator::FallibleIterator;
+use postgres::fallible_iterator::FallibleIterator;
 use postgres_protocol::types::{array_from_sql, ArrayValues};
 use tokio_postgres::{
     types::{BorrowToSql, FromSql, Kind, ToSql, Type},
     Client as PgClient, Error, RowStream, Statement, ToStatement, Transaction as PgTransaction,
 };
+
+pub use postgres_types as types;
 
 #[async_trait]
 pub trait GenericClient {

--- a/examples/auto_build/src/cornucopia.rs
+++ b/examples/auto_build/src/cornucopia.rs
@@ -17,7 +17,7 @@ pub mod queries {
         }
         pub struct ExampleQueryQuery<'a, C: GenericClient, T> {
             client: &'a C,
-            params: [&'a (dyn postgres_types::ToSql + Sync); 0],
+            params: [&'a (dyn cornucopia_client::types::ToSql + Sync); 0],
             mapper: fn(ExampleQueryBorrowed) -> T,
         }
         impl<'a, C, T> ExampleQueryQuery<'a, C, T>

--- a/examples/basic/src/cornucopia.rs
+++ b/examples/basic/src/cornucopia.rs
@@ -2,8 +2,8 @@ pub mod types {
     pub mod public {
         #[derive(
             Debug,
-            postgres_types::ToSql,
-            postgres_types::FromSql,
+            cornucopia_client::types::ToSql,
+            cornucopia_client::types::FromSql,
             Clone,
             Copy,
             PartialEq,
@@ -15,16 +15,16 @@ pub mod types {
             Patrick,
             Squidward,
         }
-        #[derive(Debug, postgres_types::ToSql, Clone, PartialEq)]
+        #[derive(Debug, cornucopia_client::types::ToSql, Clone, PartialEq)]
         #[postgres(name = "custom_composite")]
         pub struct CustomComposite {
             pub name: String,
             pub age: i32,
             pub persona: super::public::SpongebobCharacter,
         }
-        impl<'a> postgres_types::FromSql<'a> for CustomComposite {
+        impl<'a> cornucopia_client::types::FromSql<'a> for CustomComposite {
             fn from_sql(
-                _type: &postgres_types::Type,
+                _type: &cornucopia_client::types::Type,
                 buf: &'a [u8],
             ) -> std::result::Result<
                     CustomComposite,
@@ -33,23 +33,25 @@ pub mod types {
                     >,
                 > {
                 let fields = match *_type.kind() {
-                    postgres_types::Kind::Composite(ref fields) => fields,
+                    cornucopia_client::types::Kind::Composite(ref fields) => fields,
                     _ => unreachable!(),
                 };
                 let mut buf = buf;
-                let num_fields = postgres_types::private::read_be_i32(&mut buf)?;
-                let _oid = postgres_types::private::read_be_i32(&mut buf)?;
-                let name = postgres_types::private::read_value(
+                let num_fields = cornucopia_client::types::private::read_be_i32(
+                    &mut buf,
+                )?;
+                let _oid = cornucopia_client::types::private::read_be_i32(&mut buf)?;
+                let name = cornucopia_client::types::private::read_value(
                     fields[0].type_(),
                     &mut buf,
                 )?;
-                let _oid = postgres_types::private::read_be_i32(&mut buf)?;
-                let age = postgres_types::private::read_value(
+                let _oid = cornucopia_client::types::private::read_be_i32(&mut buf)?;
+                let age = cornucopia_client::types::private::read_value(
                     fields[1].type_(),
                     &mut buf,
                 )?;
-                let _oid = postgres_types::private::read_be_i32(&mut buf)?;
-                let persona = postgres_types::private::read_value(
+                let _oid = cornucopia_client::types::private::read_be_i32(&mut buf)?;
+                let persona = cornucopia_client::types::private::read_value(
                     fields[2].type_(),
                     &mut buf,
                 )?;
@@ -59,7 +61,7 @@ pub mod types {
                     persona,
                 })
             }
-            fn accepts(type_: &postgres_types::Type) -> bool {
+            fn accepts(type_: &cornucopia_client::types::Type) -> bool {
                 type_.name() == "custom_composite" && type_.schema() == "public"
             }
         }
@@ -68,9 +70,9 @@ pub mod types {
             pub age: i32,
             pub persona: super::super::types::public::SpongebobCharacter,
         }
-        impl<'a> postgres_types::FromSql<'a> for CustomCompositeBorrowed<'a> {
+        impl<'a> cornucopia_client::types::FromSql<'a> for CustomCompositeBorrowed<'a> {
             fn from_sql(
-                _type: &postgres_types::Type,
+                _type: &cornucopia_client::types::Type,
                 buf: &'a [u8],
             ) -> std::result::Result<
                     CustomCompositeBorrowed<'a>,
@@ -79,23 +81,25 @@ pub mod types {
                     >,
                 > {
                 let fields = match *_type.kind() {
-                    postgres_types::Kind::Composite(ref fields) => fields,
+                    cornucopia_client::types::Kind::Composite(ref fields) => fields,
                     _ => unreachable!(),
                 };
                 let mut buf = buf;
-                let num_fields = postgres_types::private::read_be_i32(&mut buf)?;
-                let _oid = postgres_types::private::read_be_i32(&mut buf)?;
-                let name = postgres_types::private::read_value(
+                let num_fields = cornucopia_client::types::private::read_be_i32(
+                    &mut buf,
+                )?;
+                let _oid = cornucopia_client::types::private::read_be_i32(&mut buf)?;
+                let name = cornucopia_client::types::private::read_value(
                     fields[0].type_(),
                     &mut buf,
                 )?;
-                let _oid = postgres_types::private::read_be_i32(&mut buf)?;
-                let age = postgres_types::private::read_value(
+                let _oid = cornucopia_client::types::private::read_be_i32(&mut buf)?;
+                let age = cornucopia_client::types::private::read_value(
                     fields[1].type_(),
                     &mut buf,
                 )?;
-                let _oid = postgres_types::private::read_be_i32(&mut buf)?;
-                let persona = postgres_types::private::read_value(
+                let _oid = cornucopia_client::types::private::read_be_i32(&mut buf)?;
+                let persona = cornucopia_client::types::private::read_value(
                     fields[2].type_(),
                     &mut buf,
                 )?;
@@ -105,7 +109,7 @@ pub mod types {
                     persona,
                 })
             }
-            fn accepts(type_: &postgres_types::Type) -> bool {
+            fn accepts(type_: &cornucopia_client::types::Type) -> bool {
                 type_.name() == "custom_composite" && type_.schema() == "public"
             }
         }
@@ -152,7 +156,7 @@ pub mod queries {
         }
         pub struct AuthorsQuery<'a, C: GenericClient, T> {
             client: &'a C,
-            params: [&'a (dyn postgres_types::ToSql + Sync); 0],
+            params: [&'a (dyn cornucopia_client::types::ToSql + Sync); 0],
             mapper: fn(AuthorsBorrowed) -> T,
         }
         impl<'a, C, T> AuthorsQuery<'a, C, T>
@@ -240,7 +244,7 @@ FROM
         }
         pub struct BooksQuery<'a, C: GenericClient, T> {
             client: &'a C,
-            params: [&'a (dyn postgres_types::ToSql + Sync); 0],
+            params: [&'a (dyn cornucopia_client::types::ToSql + Sync); 0],
             mapper: fn(BooksBorrowed) -> T,
         }
         impl<'a, C, T> BooksQuery<'a, C, T>
@@ -323,7 +327,7 @@ FROM
         }
         pub struct BooksOptRetParamQuery<'a, C: GenericClient, T> {
             client: &'a C,
-            params: [&'a (dyn postgres_types::ToSql + Sync); 0],
+            params: [&'a (dyn cornucopia_client::types::ToSql + Sync); 0],
             mapper: fn(BooksOptRetParamBorrowed) -> T,
         }
         impl<'a, C, T> BooksOptRetParamQuery<'a, C, T>
@@ -425,7 +429,7 @@ FROM
         }
         pub struct AuthorNameByIdQuery<'a, C: GenericClient, T> {
             client: &'a C,
-            params: [&'a (dyn postgres_types::ToSql + Sync); 1],
+            params: [&'a (dyn cornucopia_client::types::ToSql + Sync); 1],
             mapper: fn(AuthorNameByIdBorrowed) -> T,
         }
         impl<'a, C, T> AuthorNameByIdQuery<'a, C, T>
@@ -547,7 +551,7 @@ WHERE
         }
         pub struct AuthorNameStartingWithQuery<'a, C: GenericClient, T> {
             client: &'a C,
-            params: [&'a (dyn postgres_types::ToSql + Sync); 1],
+            params: [&'a (dyn cornucopia_client::types::ToSql + Sync); 1],
             mapper: fn(AuthorNameStartingWithBorrowed) -> T,
         }
         impl<'a, C, T> AuthorNameStartingWithQuery<'a, C, T>
@@ -652,7 +656,7 @@ WHERE
         }
         pub struct ReturnCustomTypeQuery<'a, C: GenericClient, T> {
             client: &'a C,
-            params: [&'a (dyn postgres_types::ToSql + Sync); 0],
+            params: [&'a (dyn cornucopia_client::types::ToSql + Sync); 0],
             mapper: fn(ReturnCustomTypeBorrowed) -> T,
         }
         impl<'a, C, T> ReturnCustomTypeQuery<'a, C, T>
@@ -744,7 +748,7 @@ FROM
         }
         pub struct SelectWhereCustomTypeQuery<'a, C: GenericClient, T> {
             client: &'a C,
-            params: [&'a (dyn postgres_types::ToSql + Sync); 1],
+            params: [&'a (dyn cornucopia_client::types::ToSql + Sync); 1],
             mapper: fn(SelectWhereCustomType) -> T,
         }
         impl<'a, C, T> SelectWhereCustomTypeQuery<'a, C, T>
@@ -842,7 +846,7 @@ WHERE (col1).persona = $1;",
         }
         pub struct SelectTranslationsQuery<'a, C: GenericClient, T> {
             client: &'a C,
-            params: [&'a (dyn postgres_types::ToSql + Sync); 0],
+            params: [&'a (dyn cornucopia_client::types::ToSql + Sync); 0],
             mapper: fn(SelectTranslationsBorrowed) -> T,
         }
         impl<'a, C, T> SelectTranslationsQuery<'a, C, T>
@@ -926,42 +930,24 @@ FROM
             pub title: &'a str,
         }
         impl<'a> InsertBookParams<'a> {
-            pub fn query<C: GenericClient>(
+            pub async fn query<C: GenericClient>(
                 &'a self,
                 client: &'a C,
-            ) -> InsertBookQuery<'a, C> {
-                insert_book(client, &self.title)
+            ) -> Result<u64, tokio_postgres::Error> {
+                insert_book(client, &self.title).await
             }
         }
-        pub struct InsertBookQuery<'a, C: GenericClient> {
-            client: &'a C,
-            params: [&'a (dyn postgres_types::ToSql + Sync); 1],
-        }
-        impl<'a, C> InsertBookQuery<'a, C>
-        where
-            C: cornucopia_client::GenericClient,
-        {
-            pub async fn stmt(
-                &self,
-            ) -> Result<tokio_postgres::Statement, tokio_postgres::Error> {
-                self.client.prepare("INSERT INTO Book (title)
-  VALUES ($1);
-
-").await
-            }
-            pub async fn exec(self) -> Result<u64, tokio_postgres::Error> {
-                let stmt = self.stmt().await?;
-                self.client.execute(&stmt, &self.params).await
-            }
-        }
-        pub fn insert_book<'a, C: GenericClient>(
+        pub async fn insert_book<'a, C: GenericClient>(
             client: &'a C,
             title: &'a &str,
-        ) -> InsertBookQuery<'a, C> {
-            InsertBookQuery {
-                client,
-                params: [title],
-            }
+        ) -> Result<u64, tokio_postgres::Error> {
+            let stmt = client
+                .prepare("INSERT INTO Book (title)
+  VALUES ($1);
+
+")
+                .await?;
+            client.execute(&stmt, &[title]).await
         }
     }
 }

--- a/examples/basic/src/main.rs
+++ b/examples/basic/src/main.rs
@@ -39,7 +39,6 @@ pub async fn main() {
         let transaction = client.transaction().await.unwrap();
         // Insert a book
         insert_book(&transaction, &"The Great Gatsby")
-            .exec()
             .await
             .unwrap();
         // Use a map if needed

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -362,22 +362,20 @@ fn generate_params_struct(
                         }}
                     }}")
         }
-    } else {
-        if params_is_copy {
-            format!(
+    } else if params_is_copy {
+        format!(
                 "impl {query_struct_name}Params {{
                     pub fn query<'a, C: GenericClient>(&'a self, client: &'a {client_mut} C) -> {ret_type} {{
                         {query_name}(client, {param_values})
                     }}
                 }}")
-        } else {
-            format!(
+    } else {
+        format!(
                 "impl<'a> {query_struct_name}Params<'a> {{
                     pub fn query<C: GenericClient>(&'a self, client: &'a {client_mut} C) -> {ret_type} {{
                         {query_name}(client, {param_values})
                     }}
                 }}")
-        }
     };
     let debug_clone_derive = if params_is_copy {
         "#[derive(Debug, Clone)]"

--- a/src/integration/cornucopia.rs
+++ b/src/integration/cornucopia.rs
@@ -2,8 +2,8 @@ pub mod types {
     pub mod public {
         #[derive(
             Debug,
-            postgres_types::ToSql,
-            postgres_types::FromSql,
+            cornucopia_client::types::ToSql,
+            cornucopia_client::types::FromSql,
             Clone,
             Copy,
             PartialEq,
@@ -15,16 +15,16 @@ pub mod types {
             Patrick,
             Squidward,
         }
-        #[derive(Debug, postgres_types::ToSql, Clone, PartialEq)]
+        #[derive(Debug, cornucopia_client::types::ToSql, Clone, PartialEq)]
         #[postgres(name = "custom_composite")]
         pub struct CustomComposite {
             pub wow: String,
             pub such_cool: i32,
             pub nice: super::public::SpongebobCharacter,
         }
-        impl<'a> postgres_types::FromSql<'a> for CustomComposite {
+        impl<'a> cornucopia_client::types::FromSql<'a> for CustomComposite {
             fn from_sql(
-                _type: &postgres_types::Type,
+                _type: &cornucopia_client::types::Type,
                 buf: &'a [u8],
             ) -> std::result::Result<
                     CustomComposite,
@@ -33,23 +33,25 @@ pub mod types {
                     >,
                 > {
                 let fields = match *_type.kind() {
-                    postgres_types::Kind::Composite(ref fields) => fields,
+                    cornucopia_client::types::Kind::Composite(ref fields) => fields,
                     _ => unreachable!(),
                 };
                 let mut buf = buf;
-                let num_fields = postgres_types::private::read_be_i32(&mut buf)?;
-                let _oid = postgres_types::private::read_be_i32(&mut buf)?;
-                let wow = postgres_types::private::read_value(
+                let num_fields = cornucopia_client::types::private::read_be_i32(
+                    &mut buf,
+                )?;
+                let _oid = cornucopia_client::types::private::read_be_i32(&mut buf)?;
+                let wow = cornucopia_client::types::private::read_value(
                     fields[0].type_(),
                     &mut buf,
                 )?;
-                let _oid = postgres_types::private::read_be_i32(&mut buf)?;
-                let such_cool = postgres_types::private::read_value(
+                let _oid = cornucopia_client::types::private::read_be_i32(&mut buf)?;
+                let such_cool = cornucopia_client::types::private::read_value(
                     fields[1].type_(),
                     &mut buf,
                 )?;
-                let _oid = postgres_types::private::read_be_i32(&mut buf)?;
-                let nice = postgres_types::private::read_value(
+                let _oid = cornucopia_client::types::private::read_be_i32(&mut buf)?;
+                let nice = cornucopia_client::types::private::read_value(
                     fields[2].type_(),
                     &mut buf,
                 )?;
@@ -59,7 +61,7 @@ pub mod types {
                     nice,
                 })
             }
-            fn accepts(type_: &postgres_types::Type) -> bool {
+            fn accepts(type_: &cornucopia_client::types::Type) -> bool {
                 type_.name() == "custom_composite" && type_.schema() == "public"
             }
         }
@@ -68,9 +70,9 @@ pub mod types {
             pub such_cool: i32,
             pub nice: super::super::types::public::SpongebobCharacter,
         }
-        impl<'a> postgres_types::FromSql<'a> for CustomCompositeBorrowed<'a> {
+        impl<'a> cornucopia_client::types::FromSql<'a> for CustomCompositeBorrowed<'a> {
             fn from_sql(
-                _type: &postgres_types::Type,
+                _type: &cornucopia_client::types::Type,
                 buf: &'a [u8],
             ) -> std::result::Result<
                     CustomCompositeBorrowed<'a>,
@@ -79,23 +81,25 @@ pub mod types {
                     >,
                 > {
                 let fields = match *_type.kind() {
-                    postgres_types::Kind::Composite(ref fields) => fields,
+                    cornucopia_client::types::Kind::Composite(ref fields) => fields,
                     _ => unreachable!(),
                 };
                 let mut buf = buf;
-                let num_fields = postgres_types::private::read_be_i32(&mut buf)?;
-                let _oid = postgres_types::private::read_be_i32(&mut buf)?;
-                let wow = postgres_types::private::read_value(
+                let num_fields = cornucopia_client::types::private::read_be_i32(
+                    &mut buf,
+                )?;
+                let _oid = cornucopia_client::types::private::read_be_i32(&mut buf)?;
+                let wow = cornucopia_client::types::private::read_value(
                     fields[0].type_(),
                     &mut buf,
                 )?;
-                let _oid = postgres_types::private::read_be_i32(&mut buf)?;
-                let such_cool = postgres_types::private::read_value(
+                let _oid = cornucopia_client::types::private::read_be_i32(&mut buf)?;
+                let such_cool = cornucopia_client::types::private::read_value(
                     fields[1].type_(),
                     &mut buf,
                 )?;
-                let _oid = postgres_types::private::read_be_i32(&mut buf)?;
-                let nice = postgres_types::private::read_value(
+                let _oid = cornucopia_client::types::private::read_be_i32(&mut buf)?;
+                let nice = cornucopia_client::types::private::read_value(
                     fields[2].type_(),
                     &mut buf,
                 )?;
@@ -105,7 +109,7 @@ pub mod types {
                     nice,
                 })
             }
-            fn accepts(type_: &postgres_types::Type) -> bool {
+            fn accepts(type_: &cornucopia_client::types::Type) -> bool {
                 type_.name() == "custom_composite" && type_.schema() == "public"
             }
         }
@@ -124,12 +128,12 @@ pub mod types {
                 }
             }
         }
-        #[derive(Debug, Clone, PartialEq, postgres_types::ToSql)]
+        #[derive(Debug, Clone, PartialEq, cornucopia_client::types::ToSql)]
         #[postgres(name = "custom_domain")]
         pub struct CustomDomain(pub Vec<super::super::types::public::CustomComposite>);
-        impl<'a> postgres_types::FromSql<'a> for CustomDomain {
+        impl<'a> cornucopia_client::types::FromSql<'a> for CustomDomain {
             fn from_sql(
-                _type: &postgres_types::Type,
+                _type: &cornucopia_client::types::Type,
                 buf: &'a [u8],
             ) -> std::result::Result<
                     CustomDomain,
@@ -138,16 +142,18 @@ pub mod types {
                     >,
                 > {
                 let inner = match *_type.kind() {
-                    postgres_types::Kind::Domain(ref inner) => inner,
+                    cornucopia_client::types::Kind::Domain(ref inner) => inner,
                     _ => unreachable!(),
                 };
                 let mut buf = buf;
-                let _oid = postgres_types::private::read_be_i32(&mut buf)?;
+                let _oid = cornucopia_client::types::private::read_be_i32(&mut buf)?;
                 std::result::Result::Ok(
-                    CustomDomain(postgres_types::private::read_value(inner, &mut buf)?),
+                    CustomDomain(
+                        cornucopia_client::types::private::read_value(inner, &mut buf)?,
+                    ),
                 )
             }
-            fn accepts(type_: &postgres_types::Type) -> bool {
+            fn accepts(type_: &cornucopia_client::types::Type) -> bool {
                 type_.name() == "custom_domain" && type_.schema() == "public"
             }
         }
@@ -157,9 +163,9 @@ pub mod types {
                 super::super::types::public::CustomCompositeBorrowed<'a>,
             >,
         );
-        impl<'a> postgres_types::FromSql<'a> for CustomDomainBorrowed<'a> {
+        impl<'a> cornucopia_client::types::FromSql<'a> for CustomDomainBorrowed<'a> {
             fn from_sql(
-                _type: &postgres_types::Type,
+                _type: &cornucopia_client::types::Type,
                 buf: &'a [u8],
             ) -> std::result::Result<
                     CustomDomainBorrowed<'a>,
@@ -168,18 +174,18 @@ pub mod types {
                     >,
                 > {
                 let inner = match *_type.kind() {
-                    postgres_types::Kind::Domain(ref inner) => inner,
+                    cornucopia_client::types::Kind::Domain(ref inner) => inner,
                     _ => unreachable!(),
                 };
                 let mut buf = buf;
-                let _oid = postgres_types::private::read_be_i32(&mut buf)?;
+                let _oid = cornucopia_client::types::private::read_be_i32(&mut buf)?;
                 std::result::Result::Ok(
                     CustomDomainBorrowed(
-                        postgres_types::private::read_value(inner, &mut buf)?,
+                        cornucopia_client::types::private::read_value(inner, &mut buf)?,
                     ),
                 )
             }
-            fn accepts(type_: &postgres_types::Type) -> bool {
+            fn accepts(type_: &cornucopia_client::types::Type) -> bool {
                 type_.name() == "custom_domain" && type_.schema() == "public"
             }
         }
@@ -188,12 +194,12 @@ pub mod types {
                 Self(inner.map(|v| v.into()).collect())
             }
         }
-        #[derive(Debug, Clone, PartialEq, postgres_types::ToSql)]
+        #[derive(Debug, Clone, PartialEq, cornucopia_client::types::ToSql)]
         #[postgres(name = "my_domain")]
         pub struct MyDomain(pub String);
-        impl<'a> postgres_types::FromSql<'a> for MyDomain {
+        impl<'a> cornucopia_client::types::FromSql<'a> for MyDomain {
             fn from_sql(
-                _type: &postgres_types::Type,
+                _type: &cornucopia_client::types::Type,
                 buf: &'a [u8],
             ) -> std::result::Result<
                     MyDomain,
@@ -202,23 +208,25 @@ pub mod types {
                     >,
                 > {
                 let inner = match *_type.kind() {
-                    postgres_types::Kind::Domain(ref inner) => inner,
+                    cornucopia_client::types::Kind::Domain(ref inner) => inner,
                     _ => unreachable!(),
                 };
                 let mut buf = buf;
-                let _oid = postgres_types::private::read_be_i32(&mut buf)?;
+                let _oid = cornucopia_client::types::private::read_be_i32(&mut buf)?;
                 std::result::Result::Ok(
-                    MyDomain(postgres_types::private::read_value(inner, &mut buf)?),
+                    MyDomain(
+                        cornucopia_client::types::private::read_value(inner, &mut buf)?,
+                    ),
                 )
             }
-            fn accepts(type_: &postgres_types::Type) -> bool {
+            fn accepts(type_: &cornucopia_client::types::Type) -> bool {
                 type_.name() == "my_domain" && type_.schema() == "public"
             }
         }
         pub struct MyDomainBorrowed<'a>(pub &'a str);
-        impl<'a> postgres_types::FromSql<'a> for MyDomainBorrowed<'a> {
+        impl<'a> cornucopia_client::types::FromSql<'a> for MyDomainBorrowed<'a> {
             fn from_sql(
-                _type: &postgres_types::Type,
+                _type: &cornucopia_client::types::Type,
                 buf: &'a [u8],
             ) -> std::result::Result<
                     MyDomainBorrowed<'a>,
@@ -227,18 +235,18 @@ pub mod types {
                     >,
                 > {
                 let inner = match *_type.kind() {
-                    postgres_types::Kind::Domain(ref inner) => inner,
+                    cornucopia_client::types::Kind::Domain(ref inner) => inner,
                     _ => unreachable!(),
                 };
                 let mut buf = buf;
-                let _oid = postgres_types::private::read_be_i32(&mut buf)?;
+                let _oid = cornucopia_client::types::private::read_be_i32(&mut buf)?;
                 std::result::Result::Ok(
                     MyDomainBorrowed(
-                        postgres_types::private::read_value(inner, &mut buf)?,
+                        cornucopia_client::types::private::read_value(inner, &mut buf)?,
                     ),
                 )
             }
-            fn accepts(type_: &postgres_types::Type) -> bool {
+            fn accepts(type_: &cornucopia_client::types::Type) -> bool {
                 type_.name() == "my_domain" && type_.schema() == "public"
             }
         }
@@ -247,15 +255,15 @@ pub mod types {
                 Self(inner.into())
             }
         }
-        #[derive(Debug, postgres_types::ToSql, Clone, PartialEq)]
+        #[derive(Debug, cornucopia_client::types::ToSql, Clone, PartialEq)]
         #[postgres(name = "nightmare_composite")]
         pub struct NightmareComposite {
             pub custom: Vec<super::super::types::public::CustomComposite>,
             pub spongebob: Vec<super::super::types::public::SpongebobCharacter>,
         }
-        impl<'a> postgres_types::FromSql<'a> for NightmareComposite {
+        impl<'a> cornucopia_client::types::FromSql<'a> for NightmareComposite {
             fn from_sql(
-                _type: &postgres_types::Type,
+                _type: &cornucopia_client::types::Type,
                 buf: &'a [u8],
             ) -> std::result::Result<
                     NightmareComposite,
@@ -264,18 +272,20 @@ pub mod types {
                     >,
                 > {
                 let fields = match *_type.kind() {
-                    postgres_types::Kind::Composite(ref fields) => fields,
+                    cornucopia_client::types::Kind::Composite(ref fields) => fields,
                     _ => unreachable!(),
                 };
                 let mut buf = buf;
-                let num_fields = postgres_types::private::read_be_i32(&mut buf)?;
-                let _oid = postgres_types::private::read_be_i32(&mut buf)?;
-                let custom = postgres_types::private::read_value(
+                let num_fields = cornucopia_client::types::private::read_be_i32(
+                    &mut buf,
+                )?;
+                let _oid = cornucopia_client::types::private::read_be_i32(&mut buf)?;
+                let custom = cornucopia_client::types::private::read_value(
                     fields[0].type_(),
                     &mut buf,
                 )?;
-                let _oid = postgres_types::private::read_be_i32(&mut buf)?;
-                let spongebob = postgres_types::private::read_value(
+                let _oid = cornucopia_client::types::private::read_be_i32(&mut buf)?;
+                let spongebob = cornucopia_client::types::private::read_value(
                     fields[1].type_(),
                     &mut buf,
                 )?;
@@ -284,7 +294,7 @@ pub mod types {
                     spongebob,
                 })
             }
-            fn accepts(type_: &postgres_types::Type) -> bool {
+            fn accepts(type_: &cornucopia_client::types::Type) -> bool {
                 type_.name() == "nightmare_composite" && type_.schema() == "public"
             }
         }
@@ -298,9 +308,10 @@ pub mod types {
                 super::super::types::public::SpongebobCharacter,
             >,
         }
-        impl<'a> postgres_types::FromSql<'a> for NightmareCompositeBorrowed<'a> {
+        impl<'a> cornucopia_client::types::FromSql<'a>
+        for NightmareCompositeBorrowed<'a> {
             fn from_sql(
-                _type: &postgres_types::Type,
+                _type: &cornucopia_client::types::Type,
                 buf: &'a [u8],
             ) -> std::result::Result<
                     NightmareCompositeBorrowed<'a>,
@@ -309,18 +320,20 @@ pub mod types {
                     >,
                 > {
                 let fields = match *_type.kind() {
-                    postgres_types::Kind::Composite(ref fields) => fields,
+                    cornucopia_client::types::Kind::Composite(ref fields) => fields,
                     _ => unreachable!(),
                 };
                 let mut buf = buf;
-                let num_fields = postgres_types::private::read_be_i32(&mut buf)?;
-                let _oid = postgres_types::private::read_be_i32(&mut buf)?;
-                let custom = postgres_types::private::read_value(
+                let num_fields = cornucopia_client::types::private::read_be_i32(
+                    &mut buf,
+                )?;
+                let _oid = cornucopia_client::types::private::read_be_i32(&mut buf)?;
+                let custom = cornucopia_client::types::private::read_value(
                     fields[0].type_(),
                     &mut buf,
                 )?;
-                let _oid = postgres_types::private::read_be_i32(&mut buf)?;
-                let spongebob = postgres_types::private::read_value(
+                let _oid = cornucopia_client::types::private::read_be_i32(&mut buf)?;
+                let spongebob = cornucopia_client::types::private::read_value(
                     fields[1].type_(),
                     &mut buf,
                 )?;
@@ -329,7 +342,7 @@ pub mod types {
                     spongebob,
                 })
             }
-            fn accepts(type_: &postgres_types::Type) -> bool {
+            fn accepts(type_: &cornucopia_client::types::Type) -> bool {
                 type_.name() == "nightmare_composite" && type_.schema() == "public"
             }
         }
@@ -346,15 +359,15 @@ pub mod types {
                 }
             }
         }
-        #[derive(Copy, Debug, postgres_types::ToSql, Clone, PartialEq)]
+        #[derive(Copy, Debug, cornucopia_client::types::ToSql, Clone, PartialEq)]
         #[postgres(name = "copy_composite")]
         pub struct CopyComposite {
             pub first: i32,
             pub second: f64,
         }
-        impl<'a> postgres_types::FromSql<'a> for CopyComposite {
+        impl<'a> cornucopia_client::types::FromSql<'a> for CopyComposite {
             fn from_sql(
-                _type: &postgres_types::Type,
+                _type: &cornucopia_client::types::Type,
                 buf: &'a [u8],
             ) -> std::result::Result<
                     CopyComposite,
@@ -363,24 +376,26 @@ pub mod types {
                     >,
                 > {
                 let fields = match *_type.kind() {
-                    postgres_types::Kind::Composite(ref fields) => fields,
+                    cornucopia_client::types::Kind::Composite(ref fields) => fields,
                     _ => unreachable!(),
                 };
                 let mut buf = buf;
-                let num_fields = postgres_types::private::read_be_i32(&mut buf)?;
-                let _oid = postgres_types::private::read_be_i32(&mut buf)?;
-                let first = postgres_types::private::read_value(
+                let num_fields = cornucopia_client::types::private::read_be_i32(
+                    &mut buf,
+                )?;
+                let _oid = cornucopia_client::types::private::read_be_i32(&mut buf)?;
+                let first = cornucopia_client::types::private::read_value(
                     fields[0].type_(),
                     &mut buf,
                 )?;
-                let _oid = postgres_types::private::read_be_i32(&mut buf)?;
-                let second = postgres_types::private::read_value(
+                let _oid = cornucopia_client::types::private::read_be_i32(&mut buf)?;
+                let second = cornucopia_client::types::private::read_value(
                     fields[1].type_(),
                     &mut buf,
                 )?;
                 std::result::Result::Ok(CopyComposite { first, second })
             }
-            fn accepts(type_: &postgres_types::Type) -> bool {
+            fn accepts(type_: &cornucopia_client::types::Type) -> bool {
                 type_.name() == "copy_composite" && type_.schema() == "public"
             }
         }
@@ -419,7 +434,7 @@ pub mod queries {
         }
         pub struct AuthorNameStartingWithQuery<'a, C: GenericClient, T> {
             client: &'a mut C,
-            params: [&'a (dyn postgres_types::ToSql + Sync); 1],
+            params: [&'a (dyn cornucopia_client::types::ToSql + Sync); 1],
             mapper: fn(AuthorNameStartingWithBorrowed) -> T,
         }
         impl<'a, C, T: 'a> AuthorNameStartingWithQuery<'a, C, T>
@@ -536,8 +551,8 @@ WHERE
             pub timestamp_with_time_zone_: time::OffsetDateTime,
             pub date_: time::Date,
             pub time_: time::Time,
-            pub json_: postgres_types::Json<&'a serde_json::value::RawValue>,
-            pub jsonb_: postgres_types::Json<&'a serde_json::value::RawValue>,
+            pub json_: cornucopia_client::types::Json<&'a serde_json::value::RawValue>,
+            pub jsonb_: cornucopia_client::types::Json<&'a serde_json::value::RawValue>,
             pub uuid_: uuid::Uuid,
             pub inet_: std::net::IpAddr,
             pub macaddr_: eui48::MacAddress,
@@ -577,8 +592,8 @@ WHERE
             pub timestamp_with_time_zone_: time::OffsetDateTime,
             pub date_: time::Date,
             pub time_: time::Time,
-            pub json_: postgres_types::Json<serde_json::Value>,
-            pub jsonb_: postgres_types::Json<serde_json::Value>,
+            pub json_: cornucopia_client::types::Json<serde_json::Value>,
+            pub jsonb_: cornucopia_client::types::Json<serde_json::Value>,
             pub uuid_: uuid::Uuid,
             pub inet_: std::net::IpAddr,
             pub macaddr_: eui48::MacAddress,
@@ -660,10 +675,10 @@ WHERE
                     timestamp_with_time_zone_,
                     date_,
                     time_,
-                    json_: postgres_types::Json(
+                    json_: cornucopia_client::types::Json(
                         serde_json::from_str(json_.0.get()).unwrap(),
                     ),
-                    jsonb_: postgres_types::Json(
+                    jsonb_: cornucopia_client::types::Json(
                         serde_json::from_str(jsonb_.0.get()).unwrap(),
                     ),
                     uuid_,
@@ -674,7 +689,7 @@ WHERE
         }
         pub struct SelectEverythingQuery<'a, C: GenericClient, T> {
             client: &'a mut C,
-            params: [&'a (dyn postgres_types::ToSql + Sync); 0],
+            params: [&'a (dyn cornucopia_client::types::ToSql + Sync); 0],
             mapper: fn(SelectEverythingBorrowed) -> T,
         }
         impl<'a, C, T: 'a> SelectEverythingQuery<'a, C, T>
@@ -853,8 +868,8 @@ FROM
             pub timestamp_with_time_zone_: time::OffsetDateTime,
             pub date_: time::Date,
             pub time_: time::Time,
-            pub json_: postgres_types::Json<&'a serde_json::value::RawValue>,
-            pub jsonb_: postgres_types::Json<&'a serde_json::value::RawValue>,
+            pub json_: cornucopia_client::types::Json<&'a serde_json::value::RawValue>,
+            pub jsonb_: cornucopia_client::types::Json<&'a serde_json::value::RawValue>,
             pub uuid_: uuid::Uuid,
             pub inet_: std::net::IpAddr,
             pub macaddr_: eui48::MacAddress,
@@ -940,8 +955,8 @@ FROM
             timestamp_with_time_zone_: &'a time::OffsetDateTime,
             date_: &'a time::Date,
             time_: &'a time::Time,
-            json_: &'a postgres_types::Json<&serde_json::value::RawValue>,
-            jsonb_: &'a postgres_types::Json<&serde_json::value::RawValue>,
+            json_: &'a cornucopia_client::types::Json<&serde_json::value::RawValue>,
+            jsonb_: &'a cornucopia_client::types::Json<&serde_json::value::RawValue>,
             uuid_: &'a uuid::Uuid,
             inet_: &'a std::net::IpAddr,
             macaddr_: &'a eui48::MacAddress,
@@ -1056,7 +1071,7 @@ FROM
         }
         pub struct NightmareQuery<'a, C: GenericClient, T> {
             client: &'a mut C,
-            params: [&'a (dyn postgres_types::ToSql + Sync); 0],
+            params: [&'a (dyn cornucopia_client::types::ToSql + Sync); 0],
             mapper: fn(NightmareBorrowed) -> T,
         }
         impl<'a, C, T: 'a> NightmareQuery<'a, C, T>
@@ -1136,7 +1151,7 @@ FROM
         }
         pub struct CopiesQuery<'a, C: GenericClient, T> {
             client: &'a mut C,
-            params: [&'a (dyn postgres_types::ToSql + Sync); 0],
+            params: [&'a (dyn cornucopia_client::types::ToSql + Sync); 0],
             mapper: fn(Copies) -> T,
         }
         impl<'a, C, T: 'a> CopiesQuery<'a, C, T>

--- a/src/integration/test.rs
+++ b/src/integration/test.rs
@@ -1,9 +1,9 @@
 use std::net::{IpAddr, Ipv4Addr};
 
 //use error::Error;
+use cornucopia_client::types::Json;
 use eui48::MacAddress;
 use postgres::Client;
-use postgres_types::Json;
 use serde_json::Map;
 use time::{OffsetDateTime, PrimitiveDateTime};
 use uuid::Uuid;

--- a/src/type_registrar.rs
+++ b/src/type_registrar.rs
@@ -1,8 +1,8 @@
+use cornucopia_client::types::{Kind, Type};
 use error::{Error, UnsupportedPostgresTypeError};
 use heck::ToUpperCamelCase;
 use indexmap::{Equivalent, IndexMap};
 use postgres::Client;
-use postgres_types::{Kind, Type};
 
 /// A struct containing a postgres type and its Rust-equivalent.
 #[derive(PartialEq, Eq, Debug, Clone)]
@@ -45,9 +45,9 @@ impl CornucopiaType {
             return "".into();
         }
 
-        if self.rust_path_from_queries == "postgres_types::Json<serde_json::Value>" {
+        if self.rust_path_from_queries == "cornucopia_client::types::Json<serde_json::Value>" {
             return format!(
-                "postgres_types::Json(serde_json::from_str({var_name}.0.get()).unwrap())"
+                "cornucopia_client::types::Json(serde_json::from_str({var_name}.0.get()).unwrap())"
             );
         }
 
@@ -123,9 +123,9 @@ impl CornucopiaType {
             "String" => {
                 format!("&{} str", lifetime.unwrap_or(""))
             }
-            "postgres_types::Json<serde_json::Value>" => {
+            "cornucopia_client::types::Json<serde_json::Value>" => {
                 format!(
-                    "postgres_types::Json<&{} serde_json::value::RawValue>",
+                    "cornucopia_client::types::Json<&{} serde_json::value::RawValue>",
                     lifetime.unwrap_or("")
                 )
             }
@@ -295,10 +295,14 @@ impl Default for TypeRegistrar {
             (Type::TIMESTAMPTZ, "time::OffsetDateTime", true),
             (Type::DATE, "time::Date", true),
             (Type::TIME, "time::Time", true),
-            (Type::JSON, "postgres_types::Json<serde_json::Value>", false),
+            (
+                Type::JSON,
+                "cornucopia_client::types::Json<serde_json::Value>",
+                false,
+            ),
             (
                 Type::JSONB,
-                "postgres_types::Json<serde_json::Value>",
+                "cornucopia_client::types::Json<serde_json::Value>",
                 false,
             ),
             (Type::UUID, "uuid::Uuid", true),
@@ -320,12 +324,12 @@ impl Default for TypeRegistrar {
             (Type::TIME_ARRAY, "Vec<time::Time>", false),
             (
                 Type::JSON_ARRAY,
-                "Vec<postgres_types::Json<serde_json::Value>>",
+                "Vec<cornucopia_client::types::Json<serde_json::Value>>",
                 false,
             ),
             (
                 Type::JSON_ARRAY,
-                "Vec<postgres_types::Json<serde_json::Value>>",
+                "Vec<cornucopia_client::types::Json<serde_json::Value>>",
                 false,
             ),
             (Type::UUID_ARRAY, "Vec<uuid::Uuid>", false),


### PR DESCRIPTION
- Make examples work again
- Export `postgres-types` from `cornucopia-client`