### PR TITLE
Use GAT to live our Query API dream

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -316,6 +316,7 @@ dependencies = [
  "async-trait",
  "cornucopia_client_core",
  "deadpool-postgres",
+ "futures",
  "tokio-postgres",
 ]
 
@@ -570,9 +571,9 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.3.21"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f73fe65f54d1e12b726f517d3e2135ca3125a437b6d998caf1962961f7172d9e"
+checksum = "7f21eda599937fba36daeb58a22e8f5cee2d14c4a17b5b7739c7c8e5e3b8230c"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -585,9 +586,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.21"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3083ce4b914124575708913bca19bfe887522d6e2e6d0952943f5eac4a74010"
+checksum = "30bdd20c28fadd505d0fd6712cdfcb0d4b5648baf45faef7f852afb2399bb050"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -595,15 +596,15 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.21"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c09fd04b7e4073ac7156a9539b57a484a8ea920f79c7c675d05d289ab6110d3"
+checksum = "4e5aa3de05362c3fb88de6531e6296e85cde7739cccad4b9dfeeb7f6ebce56bf"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.21"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9420b90cfa29e327d0429f19be13e7ddb68fa1cccb09d65e5706b8c7a749b8a6"
+checksum = "9ff63c23854bee61b6e9cd331d523909f238fc7636290b96826e9cfa5faa00ab"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -612,15 +613,15 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.21"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc4045962a5a5e935ee2fdedaa4e08284547402885ab326734432bed5d12966b"
+checksum = "bbf4d2a7a308fd4578637c0b17c7e1c7ba127b8f6ba00b29f717e9655d85eb68"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.21"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33c1e13800337f4d4d7a316bf45a567dbcb6ffe087f16424852d97e97a91f512"
+checksum = "42cd15d1c7456c04dbdf7e88bcd69760d74f3a798d6444e16974b505b0e62f17"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -629,21 +630,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.21"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21163e139fa306126e6eedaf49ecdb4588f939600f0b1e770f4205ee4b7fa868"
+checksum = "21b20ba5a92e727ba30e72834706623d94ac93a725410b6a6b6fbc1b07f7ba56"
 
 [[package]]
 name = "futures-task"
-version = "0.3.21"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c66a976bf5909d801bbef33416c41372779507e7a6b3a5e25e4749c58f776a"
+checksum = "a6508c467c73851293f390476d4491cf4d227dbabcd4170f3bb6044959b294f1"
 
 [[package]]
 name = "futures-util"
-version = "0.3.21"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8b7abd5d659d9b90c8cba917f6ec750a74e2dc23902ef9cd4cc8c8b22e6036a"
+checksum = "44fb6cb1be61cc1d2e43b262516aafcf63b241cffdb1d3fa115f91d9c7b09c90"
 dependencies = [
  "futures-channel",
  "futures-core",

--- a/bench/usage/cornucopia_benches/generated_async.rs
+++ b/bench/usage/cornucopia_benches/generated_async.rs
@@ -49,62 +49,10 @@ pub mod queries {
                 }
             }
         }
-        pub struct UserQuery<'a, C: GenericClient, T, const N: usize> {
-            client: &'a C,
-            params: [&'a (dyn postgres_types::ToSql + Sync); N],
-            stmt: &'a mut cornucopia_async::private::Stmt,
-            extractor: fn(&tokio_postgres::Row) -> UserBorrowed,
-            mapper: fn(UserBorrowed) -> T,
+        impl cornucopia_async::Borrow for User {
+            type Borrow<'r> = UserBorrowed<'r>;
         }
-        impl<'a, C, T: 'a, const N: usize> UserQuery<'a, C, T, N>
-        where
-            C: GenericClient,
-        {
-            pub fn map<R>(self, mapper: fn(UserBorrowed) -> R) -> UserQuery<'a, C, R, N> {
-                UserQuery {
-                    client: self.client,
-                    params: self.params,
-                    stmt: self.stmt,
-                    extractor: self.extractor,
-                    mapper,
-                }
-            }
 
-            pub async fn one(self) -> Result<T, tokio_postgres::Error> {
-                let stmt = self.stmt.prepare(self.client).await?;
-                let row = self.client.query_one(stmt, &self.params).await?;
-                Ok((self.mapper)((self.extractor)(&row)))
-            }
-
-            pub async fn all(self) -> Result<Vec<T>, tokio_postgres::Error> {
-                self.iter().await?.try_collect().await
-            }
-
-            pub async fn opt(self) -> Result<Option<T>, tokio_postgres::Error> {
-                let stmt = self.stmt.prepare(self.client).await?;
-                Ok(self
-                    .client
-                    .query_opt(stmt, &self.params)
-                    .await?
-                    .map(|row| (self.mapper)((self.extractor)(&row))))
-            }
-
-            pub async fn iter(
-                self,
-            ) -> Result<
-                impl futures::Stream<Item = Result<T, tokio_postgres::Error>> + 'a,
-                tokio_postgres::Error,
-            > {
-                let stmt = self.stmt.prepare(self.client).await?;
-                let it = self
-                    .client
-                    .query_raw(stmt, cornucopia_async::private::slice_iter(&self.params))
-                    .await?
-                    .map(move |res| res.map(|row| (self.mapper)((self.extractor)(&row))))
-                    .into_stream();
-                Ok(it)
-            }
-        }
         #[derive(Debug, Clone, PartialEq)]
         pub struct Post {
             pub id: i32,
@@ -135,62 +83,10 @@ pub mod queries {
                 }
             }
         }
-        pub struct PostQuery<'a, C: GenericClient, T, const N: usize> {
-            client: &'a C,
-            params: [&'a (dyn postgres_types::ToSql + Sync); N],
-            stmt: &'a mut cornucopia_async::private::Stmt,
-            extractor: fn(&tokio_postgres::Row) -> PostBorrowed,
-            mapper: fn(PostBorrowed) -> T,
+        impl cornucopia_async::Borrow for Post {
+            type Borrow<'r> = PostBorrowed<'r>;
         }
-        impl<'a, C, T: 'a, const N: usize> PostQuery<'a, C, T, N>
-        where
-            C: GenericClient,
-        {
-            pub fn map<R>(self, mapper: fn(PostBorrowed) -> R) -> PostQuery<'a, C, R, N> {
-                PostQuery {
-                    client: self.client,
-                    params: self.params,
-                    stmt: self.stmt,
-                    extractor: self.extractor,
-                    mapper,
-                }
-            }
 
-            pub async fn one(self) -> Result<T, tokio_postgres::Error> {
-                let stmt = self.stmt.prepare(self.client).await?;
-                let row = self.client.query_one(stmt, &self.params).await?;
-                Ok((self.mapper)((self.extractor)(&row)))
-            }
-
-            pub async fn all(self) -> Result<Vec<T>, tokio_postgres::Error> {
-                self.iter().await?.try_collect().await
-            }
-
-            pub async fn opt(self) -> Result<Option<T>, tokio_postgres::Error> {
-                let stmt = self.stmt.prepare(self.client).await?;
-                Ok(self
-                    .client
-                    .query_opt(stmt, &self.params)
-                    .await?
-                    .map(|row| (self.mapper)((self.extractor)(&row))))
-            }
-
-            pub async fn iter(
-                self,
-            ) -> Result<
-                impl futures::Stream<Item = Result<T, tokio_postgres::Error>> + 'a,
-                tokio_postgres::Error,
-            > {
-                let stmt = self.stmt.prepare(self.client).await?;
-                let it = self
-                    .client
-                    .query_raw(stmt, cornucopia_async::private::slice_iter(&self.params))
-                    .await?
-                    .map(move |res| res.map(|row| (self.mapper)((self.extractor)(&row))))
-                    .into_stream();
-                Ok(it)
-            }
-        }
         #[derive(Debug, Clone, PartialEq)]
         pub struct Comment {
             pub id: i32,
@@ -211,62 +107,10 @@ pub mod queries {
                 }
             }
         }
-        pub struct CommentQuery<'a, C: GenericClient, T, const N: usize> {
-            client: &'a C,
-            params: [&'a (dyn postgres_types::ToSql + Sync); N],
-            stmt: &'a mut cornucopia_async::private::Stmt,
-            extractor: fn(&tokio_postgres::Row) -> CommentBorrowed,
-            mapper: fn(CommentBorrowed) -> T,
+        impl cornucopia_async::Borrow for Comment {
+            type Borrow<'r> = CommentBorrowed<'r>;
         }
-        impl<'a, C, T: 'a, const N: usize> CommentQuery<'a, C, T, N>
-        where
-            C: GenericClient,
-        {
-            pub fn map<R>(self, mapper: fn(CommentBorrowed) -> R) -> CommentQuery<'a, C, R, N> {
-                CommentQuery {
-                    client: self.client,
-                    params: self.params,
-                    stmt: self.stmt,
-                    extractor: self.extractor,
-                    mapper,
-                }
-            }
 
-            pub async fn one(self) -> Result<T, tokio_postgres::Error> {
-                let stmt = self.stmt.prepare(self.client).await?;
-                let row = self.client.query_one(stmt, &self.params).await?;
-                Ok((self.mapper)((self.extractor)(&row)))
-            }
-
-            pub async fn all(self) -> Result<Vec<T>, tokio_postgres::Error> {
-                self.iter().await?.try_collect().await
-            }
-
-            pub async fn opt(self) -> Result<Option<T>, tokio_postgres::Error> {
-                let stmt = self.stmt.prepare(self.client).await?;
-                Ok(self
-                    .client
-                    .query_opt(stmt, &self.params)
-                    .await?
-                    .map(|row| (self.mapper)((self.extractor)(&row))))
-            }
-
-            pub async fn iter(
-                self,
-            ) -> Result<
-                impl futures::Stream<Item = Result<T, tokio_postgres::Error>> + 'a,
-                tokio_postgres::Error,
-            > {
-                let stmt = self.stmt.prepare(self.client).await?;
-                let it = self
-                    .client
-                    .query_raw(stmt, cornucopia_async::private::slice_iter(&self.params))
-                    .await?
-                    .map(move |res| res.map(|row| (self.mapper)((self.extractor)(&row))))
-                    .into_stream();
-                Ok(it)
-            }
-        }
         #[derive(Debug, Clone, PartialEq)]
         pub struct SelectComplex {
             pub myuser_id: i32,
@@ -309,64 +153,8 @@ pub mod queries {
                 }
             }
         }
-        pub struct SelectComplexQuery<'a, C: GenericClient, T, const N: usize> {
-            client: &'a C,
-            params: [&'a (dyn postgres_types::ToSql + Sync); N],
-            stmt: &'a mut cornucopia_async::private::Stmt,
-            extractor: fn(&tokio_postgres::Row) -> SelectComplexBorrowed,
-            mapper: fn(SelectComplexBorrowed) -> T,
-        }
-        impl<'a, C, T: 'a, const N: usize> SelectComplexQuery<'a, C, T, N>
-        where
-            C: GenericClient,
-        {
-            pub fn map<R>(
-                self,
-                mapper: fn(SelectComplexBorrowed) -> R,
-            ) -> SelectComplexQuery<'a, C, R, N> {
-                SelectComplexQuery {
-                    client: self.client,
-                    params: self.params,
-                    stmt: self.stmt,
-                    extractor: self.extractor,
-                    mapper,
-                }
-            }
-
-            pub async fn one(self) -> Result<T, tokio_postgres::Error> {
-                let stmt = self.stmt.prepare(self.client).await?;
-                let row = self.client.query_one(stmt, &self.params).await?;
-                Ok((self.mapper)((self.extractor)(&row)))
-            }
-
-            pub async fn all(self) -> Result<Vec<T>, tokio_postgres::Error> {
-                self.iter().await?.try_collect().await
-            }
-
-            pub async fn opt(self) -> Result<Option<T>, tokio_postgres::Error> {
-                let stmt = self.stmt.prepare(self.client).await?;
-                Ok(self
-                    .client
-                    .query_opt(stmt, &self.params)
-                    .await?
-                    .map(|row| (self.mapper)((self.extractor)(&row))))
-            }
-
-            pub async fn iter(
-                self,
-            ) -> Result<
-                impl futures::Stream<Item = Result<T, tokio_postgres::Error>> + 'a,
-                tokio_postgres::Error,
-            > {
-                let stmt = self.stmt.prepare(self.client).await?;
-                let it = self
-                    .client
-                    .query_raw(stmt, cornucopia_async::private::slice_iter(&self.params))
-                    .await?
-                    .map(move |res| res.map(|row| (self.mapper)((self.extractor)(&row))))
-                    .into_stream();
-                Ok(it)
-            }
+        impl cornucopia_async::Borrow for SelectComplex {
+            type Borrow<'r> = SelectComplexBorrowed<'r>;
         }
         pub fn users() -> UsersStmt {
             UsersStmt(cornucopia_async::private::Stmt::new("SELECT * FROM users"))
@@ -376,8 +164,8 @@ pub mod queries {
             pub fn bind<'a, C: GenericClient>(
                 &'a mut self,
                 client: &'a C,
-            ) -> UserQuery<'a, C, User, 0> {
-                UserQuery {
+            ) -> cornucopia_async::private::Query<'a, C, User, User, 0> {
+                cornucopia_async::private::Query {
                     client,
                     params: [],
                     stmt: &mut self.0,
@@ -450,8 +238,8 @@ pub mod queries {
             pub fn bind<'a, C: GenericClient>(
                 &'a mut self,
                 client: &'a C,
-            ) -> PostQuery<'a, C, Post, 0> {
-                PostQuery {
+            ) -> cornucopia_async::private::Query<'a, C, Post, Post, 0> {
+                cornucopia_async::private::Query {
                     client,
                     params: [],
                     stmt: &mut self.0,
@@ -476,8 +264,8 @@ pub mod queries {
                 &'a mut self,
                 client: &'a C,
                 ids: &'a T1,
-            ) -> PostQuery<'a, C, Post, 1> {
-                PostQuery {
+            ) -> cornucopia_async::private::Query<'a, C, Post, Post, 1> {
+                cornucopia_async::private::Query {
                     client,
                     params: [ids],
                     stmt: &mut self.0,
@@ -501,8 +289,8 @@ pub mod queries {
             pub fn bind<'a, C: GenericClient>(
                 &'a mut self,
                 client: &'a C,
-            ) -> CommentQuery<'a, C, Comment, 0> {
-                CommentQuery {
+            ) -> cornucopia_async::private::Query<'a, C, Comment, Comment, 0> {
+                cornucopia_async::private::Query {
                     client,
                     params: [],
                     stmt: &mut self.0,
@@ -526,8 +314,8 @@ pub mod queries {
                 &'a mut self,
                 client: &'a C,
                 ids: &'a T1,
-            ) -> CommentQuery<'a, C, Comment, 1> {
-                CommentQuery {
+            ) -> cornucopia_async::private::Query<'a, C, Comment, Comment, 1> {
+                cornucopia_async::private::Query {
                     client,
                     params: [ids],
                     stmt: &mut self.0,
@@ -548,8 +336,9 @@ pub mod queries {
             pub fn bind<'a, C: GenericClient>(
                 &'a mut self,
                 client: &'a C,
-            ) -> SelectComplexQuery<'a, C, SelectComplex, 0> {
-                SelectComplexQuery {
+            ) -> cornucopia_async::private::Query<'a, C, SelectComplex, SelectComplex, 0>
+            {
+                cornucopia_async::private::Query {
                     client,
                     params: [],
                     stmt: &mut self.0,

--- a/bench/usage/cornucopia_benches/generated_sync.rs
+++ b/bench/usage/cornucopia_benches/generated_sync.rs
@@ -44,58 +44,10 @@ pub mod queries {
                 }
             }
         }
-        pub struct UserQuery<'a, C: GenericClient, T, const N: usize> {
-            client: &'a mut C,
-            params: [&'a (dyn postgres_types::ToSql + Sync); N],
-            stmt: &'a mut cornucopia_sync::private::Stmt,
-            extractor: fn(&postgres::Row) -> UserBorrowed,
-            mapper: fn(UserBorrowed) -> T,
+        impl cornucopia_sync::Borrow for User {
+            type Borrow<'r> = UserBorrowed<'r>;
         }
-        impl<'a, C, T: 'a, const N: usize> UserQuery<'a, C, T, N>
-        where
-            C: GenericClient,
-        {
-            pub fn map<R>(self, mapper: fn(UserBorrowed) -> R) -> UserQuery<'a, C, R, N> {
-                UserQuery {
-                    client: self.client,
-                    params: self.params,
-                    stmt: self.stmt,
-                    extractor: self.extractor,
-                    mapper,
-                }
-            }
 
-            pub fn one(self) -> Result<T, postgres::Error> {
-                let stmt = self.stmt.prepare(self.client)?;
-                let row = self.client.query_one(stmt, &self.params)?;
-                Ok((self.mapper)((self.extractor)(&row)))
-            }
-
-            pub fn all(self) -> Result<Vec<T>, postgres::Error> {
-                self.iter()?.collect()
-            }
-
-            pub fn opt(self) -> Result<Option<T>, postgres::Error> {
-                let stmt = self.stmt.prepare(self.client)?;
-                Ok(self
-                    .client
-                    .query_opt(stmt, &self.params)?
-                    .map(|row| (self.mapper)((self.extractor)(&row))))
-            }
-
-            pub fn iter(
-                self,
-            ) -> Result<impl Iterator<Item = Result<T, postgres::Error>> + 'a, postgres::Error>
-            {
-                let stmt = self.stmt.prepare(self.client)?;
-                let it = self
-                    .client
-                    .query_raw(stmt, cornucopia_sync::private::slice_iter(&self.params))?
-                    .iterator()
-                    .map(move |res| res.map(|row| (self.mapper)((self.extractor)(&row))));
-                Ok(it)
-            }
-        }
         #[derive(Debug, Clone, PartialEq)]
         pub struct Post {
             pub id: i32,
@@ -126,58 +78,10 @@ pub mod queries {
                 }
             }
         }
-        pub struct PostQuery<'a, C: GenericClient, T, const N: usize> {
-            client: &'a mut C,
-            params: [&'a (dyn postgres_types::ToSql + Sync); N],
-            stmt: &'a mut cornucopia_sync::private::Stmt,
-            extractor: fn(&postgres::Row) -> PostBorrowed,
-            mapper: fn(PostBorrowed) -> T,
+        impl cornucopia_sync::Borrow for Post {
+            type Borrow<'r> = PostBorrowed<'r>;
         }
-        impl<'a, C, T: 'a, const N: usize> PostQuery<'a, C, T, N>
-        where
-            C: GenericClient,
-        {
-            pub fn map<R>(self, mapper: fn(PostBorrowed) -> R) -> PostQuery<'a, C, R, N> {
-                PostQuery {
-                    client: self.client,
-                    params: self.params,
-                    stmt: self.stmt,
-                    extractor: self.extractor,
-                    mapper,
-                }
-            }
 
-            pub fn one(self) -> Result<T, postgres::Error> {
-                let stmt = self.stmt.prepare(self.client)?;
-                let row = self.client.query_one(stmt, &self.params)?;
-                Ok((self.mapper)((self.extractor)(&row)))
-            }
-
-            pub fn all(self) -> Result<Vec<T>, postgres::Error> {
-                self.iter()?.collect()
-            }
-
-            pub fn opt(self) -> Result<Option<T>, postgres::Error> {
-                let stmt = self.stmt.prepare(self.client)?;
-                Ok(self
-                    .client
-                    .query_opt(stmt, &self.params)?
-                    .map(|row| (self.mapper)((self.extractor)(&row))))
-            }
-
-            pub fn iter(
-                self,
-            ) -> Result<impl Iterator<Item = Result<T, postgres::Error>> + 'a, postgres::Error>
-            {
-                let stmt = self.stmt.prepare(self.client)?;
-                let it = self
-                    .client
-                    .query_raw(stmt, cornucopia_sync::private::slice_iter(&self.params))?
-                    .iterator()
-                    .map(move |res| res.map(|row| (self.mapper)((self.extractor)(&row))));
-                Ok(it)
-            }
-        }
         #[derive(Debug, Clone, PartialEq)]
         pub struct Comment {
             pub id: i32,
@@ -198,58 +102,10 @@ pub mod queries {
                 }
             }
         }
-        pub struct CommentQuery<'a, C: GenericClient, T, const N: usize> {
-            client: &'a mut C,
-            params: [&'a (dyn postgres_types::ToSql + Sync); N],
-            stmt: &'a mut cornucopia_sync::private::Stmt,
-            extractor: fn(&postgres::Row) -> CommentBorrowed,
-            mapper: fn(CommentBorrowed) -> T,
+        impl cornucopia_sync::Borrow for Comment {
+            type Borrow<'r> = CommentBorrowed<'r>;
         }
-        impl<'a, C, T: 'a, const N: usize> CommentQuery<'a, C, T, N>
-        where
-            C: GenericClient,
-        {
-            pub fn map<R>(self, mapper: fn(CommentBorrowed) -> R) -> CommentQuery<'a, C, R, N> {
-                CommentQuery {
-                    client: self.client,
-                    params: self.params,
-                    stmt: self.stmt,
-                    extractor: self.extractor,
-                    mapper,
-                }
-            }
 
-            pub fn one(self) -> Result<T, postgres::Error> {
-                let stmt = self.stmt.prepare(self.client)?;
-                let row = self.client.query_one(stmt, &self.params)?;
-                Ok((self.mapper)((self.extractor)(&row)))
-            }
-
-            pub fn all(self) -> Result<Vec<T>, postgres::Error> {
-                self.iter()?.collect()
-            }
-
-            pub fn opt(self) -> Result<Option<T>, postgres::Error> {
-                let stmt = self.stmt.prepare(self.client)?;
-                Ok(self
-                    .client
-                    .query_opt(stmt, &self.params)?
-                    .map(|row| (self.mapper)((self.extractor)(&row))))
-            }
-
-            pub fn iter(
-                self,
-            ) -> Result<impl Iterator<Item = Result<T, postgres::Error>> + 'a, postgres::Error>
-            {
-                let stmt = self.stmt.prepare(self.client)?;
-                let it = self
-                    .client
-                    .query_raw(stmt, cornucopia_sync::private::slice_iter(&self.params))?
-                    .iterator()
-                    .map(move |res| res.map(|row| (self.mapper)((self.extractor)(&row))));
-                Ok(it)
-            }
-        }
         #[derive(Debug, Clone, PartialEq)]
         pub struct SelectComplex {
             pub myuser_id: i32,
@@ -292,60 +148,8 @@ pub mod queries {
                 }
             }
         }
-        pub struct SelectComplexQuery<'a, C: GenericClient, T, const N: usize> {
-            client: &'a mut C,
-            params: [&'a (dyn postgres_types::ToSql + Sync); N],
-            stmt: &'a mut cornucopia_sync::private::Stmt,
-            extractor: fn(&postgres::Row) -> SelectComplexBorrowed,
-            mapper: fn(SelectComplexBorrowed) -> T,
-        }
-        impl<'a, C, T: 'a, const N: usize> SelectComplexQuery<'a, C, T, N>
-        where
-            C: GenericClient,
-        {
-            pub fn map<R>(
-                self,
-                mapper: fn(SelectComplexBorrowed) -> R,
-            ) -> SelectComplexQuery<'a, C, R, N> {
-                SelectComplexQuery {
-                    client: self.client,
-                    params: self.params,
-                    stmt: self.stmt,
-                    extractor: self.extractor,
-                    mapper,
-                }
-            }
-
-            pub fn one(self) -> Result<T, postgres::Error> {
-                let stmt = self.stmt.prepare(self.client)?;
-                let row = self.client.query_one(stmt, &self.params)?;
-                Ok((self.mapper)((self.extractor)(&row)))
-            }
-
-            pub fn all(self) -> Result<Vec<T>, postgres::Error> {
-                self.iter()?.collect()
-            }
-
-            pub fn opt(self) -> Result<Option<T>, postgres::Error> {
-                let stmt = self.stmt.prepare(self.client)?;
-                Ok(self
-                    .client
-                    .query_opt(stmt, &self.params)?
-                    .map(|row| (self.mapper)((self.extractor)(&row))))
-            }
-
-            pub fn iter(
-                self,
-            ) -> Result<impl Iterator<Item = Result<T, postgres::Error>> + 'a, postgres::Error>
-            {
-                let stmt = self.stmt.prepare(self.client)?;
-                let it = self
-                    .client
-                    .query_raw(stmt, cornucopia_sync::private::slice_iter(&self.params))?
-                    .iterator()
-                    .map(move |res| res.map(|row| (self.mapper)((self.extractor)(&row))));
-                Ok(it)
-            }
+        impl cornucopia_sync::Borrow for SelectComplex {
+            type Borrow<'r> = SelectComplexBorrowed<'r>;
         }
         pub fn users() -> UsersStmt {
             UsersStmt(cornucopia_sync::private::Stmt::new("SELECT * FROM users"))
@@ -355,8 +159,8 @@ pub mod queries {
             pub fn bind<'a, C: GenericClient>(
                 &'a mut self,
                 client: &'a mut C,
-            ) -> UserQuery<'a, C, User, 0> {
-                UserQuery {
+            ) -> cornucopia_sync::private::Query<'a, C, User, User, 0> {
+                cornucopia_sync::private::Query {
                     client,
                     params: [],
                     stmt: &mut self.0,
@@ -417,8 +221,8 @@ pub mod queries {
             pub fn bind<'a, C: GenericClient>(
                 &'a mut self,
                 client: &'a mut C,
-            ) -> PostQuery<'a, C, Post, 0> {
-                PostQuery {
+            ) -> cornucopia_sync::private::Query<'a, C, Post, Post, 0> {
+                cornucopia_sync::private::Query {
                     client,
                     params: [],
                     stmt: &mut self.0,
@@ -443,8 +247,8 @@ pub mod queries {
                 &'a mut self,
                 client: &'a mut C,
                 ids: &'a T1,
-            ) -> PostQuery<'a, C, Post, 1> {
-                PostQuery {
+            ) -> cornucopia_sync::private::Query<'a, C, Post, Post, 1> {
+                cornucopia_sync::private::Query {
                     client,
                     params: [ids],
                     stmt: &mut self.0,
@@ -468,8 +272,8 @@ pub mod queries {
             pub fn bind<'a, C: GenericClient>(
                 &'a mut self,
                 client: &'a mut C,
-            ) -> CommentQuery<'a, C, Comment, 0> {
-                CommentQuery {
+            ) -> cornucopia_sync::private::Query<'a, C, Comment, Comment, 0> {
+                cornucopia_sync::private::Query {
                     client,
                     params: [],
                     stmt: &mut self.0,
@@ -493,8 +297,8 @@ pub mod queries {
                 &'a mut self,
                 client: &'a mut C,
                 ids: &'a T1,
-            ) -> CommentQuery<'a, C, Comment, 1> {
-                CommentQuery {
+            ) -> cornucopia_sync::private::Query<'a, C, Comment, Comment, 1> {
+                cornucopia_sync::private::Query {
                     client,
                     params: [ids],
                     stmt: &mut self.0,
@@ -515,8 +319,9 @@ pub mod queries {
             pub fn bind<'a, C: GenericClient>(
                 &'a mut self,
                 client: &'a mut C,
-            ) -> SelectComplexQuery<'a, C, SelectComplex, 0> {
-                SelectComplexQuery {
+            ) -> cornucopia_sync::private::Query<'a, C, SelectComplex, SelectComplex, 0>
+            {
+                cornucopia_sync::private::Query {
                     client,
                     params: [],
                     stmt: &mut self.0,

--- a/clients/async/Cargo.toml
+++ b/clients/async/Cargo.toml
@@ -21,5 +21,5 @@ with-serde_json-1 = ["cornucopia_client_core/with-serde_json-1"]
 tokio-postgres = { version = "0.7.6" }
 async-trait = { version = "0.1.56" }
 deadpool-postgres = { version = "0.10.2", optional = true }
-
+futures = "0.3.24"
 cornucopia_client_core = { path = "../core", version = "0.3.1"  }

--- a/clients/async/src/lib.rs
+++ b/clients/async/src/lib.rs
@@ -1,8 +1,12 @@
+#![feature(generic_associated_types)]
+
 #[doc(hidden)]
 pub mod private;
 
 pub use crate::generic_client::GenericClient;
-pub use cornucopia_client_core::{ArrayIterator, ArraySql, BytesSql, IterSql, JsonSql, StringSql};
+pub use cornucopia_client_core::{
+    ArrayIterator, ArraySql, Borrow, BytesSql, IterSql, JsonSql, StringSql,
+};
 
 #[cfg(feature = "deadpool")]
 mod deadpool;

--- a/clients/async/src/private.rs
+++ b/clients/async/src/private.rs
@@ -1,7 +1,9 @@
+use cornucopia_client_core::Borrow;
 pub use cornucopia_client_core::{slice_iter, Domain, DomainArray};
 
 use crate::generic_client::GenericClient;
-use tokio_postgres::{Error, Statement};
+use futures::{Stream, StreamExt, TryStreamExt};
+use tokio_postgres::{types::ToSql, Error, Row, Statement};
 
 /// Cached statement
 pub struct Stmt {
@@ -28,5 +30,55 @@ impl Stmt {
         }
         // the statement is always prepared at this point
         Ok(unsafe { self.cached.as_ref().unwrap_unchecked() })
+    }
+}
+
+pub struct Query<'a, C: GenericClient, T, B: Borrow, const N: usize> {
+    pub client: &'a C,
+    pub params: [&'a (dyn ToSql + Sync); N],
+    pub stmt: &'a mut Stmt,
+    pub extractor: for<'r> fn(&'r Row) -> B::Borrow<'r>,
+    pub mapper: for<'r> fn(B::Borrow<'r>) -> T,
+}
+
+impl<'a, C: GenericClient, T: 'a, B: Borrow, const N: usize> Query<'a, C, T, B, N> {
+    pub fn map<R>(self, mapper: for<'b> fn(B::Borrow<'b>) -> R) -> Query<'a, C, R, B, N> {
+        Query {
+            client: self.client,
+            params: self.params,
+            stmt: self.stmt,
+            extractor: self.extractor,
+            mapper,
+        }
+    }
+
+    pub async fn one(&mut self) -> Result<T, Error> {
+        let stmt = self.stmt.prepare(self.client).await?;
+        let row = self.client.query_one(stmt, &self.params).await?;
+        Ok((self.mapper)((self.extractor)(&row)))
+    }
+
+    pub async fn opt(&mut self) -> Result<Option<T>, Error> {
+        let stmt = self.stmt.prepare(self.client).await?;
+        Ok(self
+            .client
+            .query_opt(stmt, &self.params)
+            .await?
+            .map(|row| (self.mapper)((self.extractor)(&row))))
+    }
+
+    pub async fn all(&'a mut self) -> Result<Vec<T>, Error> {
+        self.iter().await?.try_collect().await
+    }
+
+    pub async fn iter(&'a mut self) -> Result<impl Stream<Item = Result<T, Error>> + 'a, Error> {
+        let stmt = self.stmt.prepare(self.client).await?;
+        let stream = self
+            .client
+            .query_raw(stmt, slice_iter(&self.params))
+            .await?
+            .map(move |res| res.map(|row| (self.mapper)((self.extractor)(&row))))
+            .into_stream();
+        Ok(stream)
     }
 }

--- a/clients/core/src/lib.rs
+++ b/clients/core/src/lib.rs
@@ -1,3 +1,5 @@
+#![feature(generic_associated_types)]
+
 mod array_iterator;
 mod domain;
 mod utils;
@@ -154,3 +156,32 @@ fn downcast(len: usize) -> Result<i32, Box<dyn std::error::Error + Sync + Send>>
         Ok(len as i32)
     }
 }
+
+pub trait Borrow {
+    type Borrow<'r>: 'r;
+}
+
+macro_rules! borrow {
+    ($ty:ty) => {
+        borrow!($ty, $ty);
+    };
+    ($own:ty, $brw:ty) => {
+        impl Borrow for $own {
+            type Borrow<'r> = $brw;
+        }
+        impl Borrow for Vec<$own> {
+            type Borrow<'r> = ArrayIterator<'r, $brw>;
+        }
+        impl Borrow for Option<$own> {
+            type Borrow<'r> = Option<$brw>;
+        }
+    };
+}
+
+borrow!(bool);
+borrow!(i16);
+borrow!(i32);
+borrow!(i64);
+borrow!(f32);
+borrow!(f64);
+borrow!(String, &'r str);

--- a/clients/sync/src/lib.rs
+++ b/clients/sync/src/lib.rs
@@ -1,7 +1,11 @@
+#![feature(generic_associated_types)]
+
 #[doc(hidden)]
 pub mod private;
 
-pub use cornucopia_client_core::{ArrayIterator, ArraySql, BytesSql, IterSql, JsonSql, StringSql};
+pub use cornucopia_client_core::{
+    ArrayIterator, ArraySql, Borrow, BytesSql, IterSql, JsonSql, StringSql,
+};
 
 /// This trait allows you to bind parameters to a query using a single
 /// struct, rather than passing each bind parameter as a function parameter.

--- a/clients/sync/src/private.rs
+++ b/clients/sync/src/private.rs
@@ -1,6 +1,9 @@
+use cornucopia_client_core::Borrow;
 pub use cornucopia_client_core::{slice_iter, Domain, DomainArray};
 
-use postgres::Statement;
+use postgres::{
+    fallible_iterator::FallibleIterator, types::ToSql, Error, GenericClient, Row, Statement,
+};
 
 /// Cached statement
 pub struct Stmt {
@@ -27,5 +30,59 @@ impl Stmt {
         }
         // the statement is always prepared at this point
         Ok(unsafe { self.cached.as_ref().unwrap_unchecked() })
+    }
+}
+
+pub struct Query<'a, C: GenericClient, T, B, const N: usize>
+where
+    B: Borrow,
+{
+    pub client: &'a mut C,
+    pub params: [&'a (dyn ToSql + Sync); N],
+    pub stmt: &'a mut Stmt,
+    pub extractor: for<'r> fn(&'r Row) -> B::Borrow<'r>,
+    pub mapper: for<'r> fn(B::Borrow<'r>) -> T,
+}
+
+impl<'a, C, T: 'a, B: Borrow, const N: usize> Query<'a, C, T, B, N>
+where
+    C: GenericClient,
+{
+    pub fn map<R>(self, mapper: for<'b> fn(B::Borrow<'b>) -> R) -> Query<'a, C, R, B, N> {
+        Query {
+            client: self.client,
+            params: self.params,
+            stmt: self.stmt,
+            extractor: self.extractor,
+            mapper,
+        }
+    }
+
+    pub fn one(&mut self) -> Result<T, Error> {
+        let stmt = self.stmt.prepare(self.client)?;
+        let row = self.client.query_one(stmt, &self.params)?;
+        Ok((self.mapper)((self.extractor)(&row)))
+    }
+
+    pub fn opt(&mut self) -> Result<Option<T>, Error> {
+        let stmt = self.stmt.prepare(self.client)?;
+        Ok(self
+            .client
+            .query_opt(stmt, &self.params)?
+            .map(|row| (self.mapper)((self.extractor)(&row))))
+    }
+
+    pub fn all(&'a mut self) -> Result<Vec<T>, Error> {
+        self.iter()?.collect()
+    }
+
+    pub fn iter(&'a mut self) -> Result<impl Iterator<Item = Result<T, Error>> + 'a, Error> {
+        let stmt = self.stmt.prepare(self.client)?;
+        let stream = self
+            .client
+            .query_raw(stmt, slice_iter(&self.params))?
+            .iterator()
+            .map(|res| res.map(|row| (self.mapper)((self.extractor)(&row))));
+        Ok(stream)
     }
 }

--- a/codegen_test/src/cornucopia_async.rs
+++ b/codegen_test/src/cornucopia_async.rs
@@ -25,6 +25,9 @@ pub mod types {
                 }
             }
         }
+        impl cornucopia_async::Borrow for CloneComposite {
+            type Borrow<'r> = CloneCompositeBorrowed<'r>;
+        }
         impl<'a> postgres_types::FromSql<'a> for CloneCompositeBorrowed<'a> {
             fn from_sql(
                 ty: &postgres_types::Type,
@@ -180,6 +183,9 @@ pub mod types {
                 postgres_types::__to_sql_checked(self, ty, out)
             }
         }
+        impl cornucopia_async::Borrow for CopyComposite {
+            type Borrow<'r> = CopyComposite;
+        }
         #[derive(serde::Serialize, Debug, postgres_types::FromSql, Clone, PartialEq)]
         #[postgres(name = "domain_composite")]
         pub struct DomainComposite {
@@ -211,6 +217,9 @@ pub mod types {
                         .collect(),
                 }
             }
+        }
+        impl cornucopia_async::Borrow for DomainComposite {
+            type Borrow<'r> = DomainCompositeBorrowed<'r>;
         }
         impl<'a> postgres_types::FromSql<'a> for DomainCompositeBorrowed<'a> {
             fn from_sql(
@@ -350,6 +359,9 @@ pub mod types {
                 }
             }
         }
+        impl cornucopia_async::Borrow for NamedComposite {
+            type Borrow<'r> = NamedCompositeBorrowed<'r>;
+        }
         impl<'a> postgres_types::FromSql<'a> for NamedCompositeBorrowed<'a> {
             fn from_sql(
                 ty: &postgres_types::Type,
@@ -463,6 +475,9 @@ pub mod types {
                 }
             }
         }
+        impl cornucopia_async::Borrow for NullityComposite {
+            type Borrow<'r> = NullityCompositeBorrowed<'r>;
+        }
         impl<'a> postgres_types::FromSql<'a> for NullityCompositeBorrowed<'a> {
             fn from_sql(
                 ty: &postgres_types::Type,
@@ -570,6 +585,9 @@ pub mod types {
             Patrick,
             Squidward,
         }
+        impl cornucopia_async::Borrow for SpongebobCharacter {
+            type Borrow<'r> = SpongebobCharacter;
+        }
         #[derive(serde::Serialize, Debug, postgres_types::FromSql, Clone, PartialEq)]
         #[postgres(name = "custom_composite")]
         pub struct CustomComposite {
@@ -597,6 +615,9 @@ pub mod types {
                     nice,
                 }
             }
+        }
+        impl cornucopia_async::Borrow for CustomComposite {
+            type Borrow<'r> = CustomCompositeBorrowed<'r>;
         }
         impl<'a> postgres_types::FromSql<'a> for CustomCompositeBorrowed<'a> {
             fn from_sql(
@@ -730,6 +751,9 @@ pub mod types {
                 }
             }
         }
+        impl cornucopia_async::Borrow for NightmareComposite {
+            type Borrow<'r> = NightmareCompositeBorrowed<'r>;
+        }
         impl<'a> postgres_types::FromSql<'a> for NightmareCompositeBorrowed<'a> {
             fn from_sql(
                 ty: &postgres_types::Type,
@@ -850,126 +874,6 @@ pub mod queries {
         use futures;
         use futures::{StreamExt, TryStreamExt};
 
-        pub struct SuperSuperTypesPublicCloneCompositeQuery<'a, C: GenericClient, T, const N: usize> {
-            client: &'a C,
-            params: [&'a (dyn postgres_types::ToSql + Sync); N],
-            stmt: &'a mut cornucopia_async::private::Stmt,
-            extractor:
-                fn(&tokio_postgres::Row) -> super::super::types::public::CloneCompositeBorrowed,
-            mapper: fn(super::super::types::public::CloneCompositeBorrowed) -> T,
-        }
-        impl<'a, C, T: 'a, const N: usize> SuperSuperTypesPublicCloneCompositeQuery<'a, C, T, N>
-        where
-            C: GenericClient,
-        {
-            pub fn map<R>(
-                self,
-                mapper: fn(super::super::types::public::CloneCompositeBorrowed) -> R,
-            ) -> SuperSuperTypesPublicCloneCompositeQuery<'a, C, R, N> {
-                SuperSuperTypesPublicCloneCompositeQuery {
-                    client: self.client,
-                    params: self.params,
-                    stmt: self.stmt,
-                    extractor: self.extractor,
-                    mapper,
-                }
-            }
-
-            pub async fn one(self) -> Result<T, tokio_postgres::Error> {
-                let stmt = self.stmt.prepare(self.client).await?;
-                let row = self.client.query_one(stmt, &self.params).await?;
-                Ok((self.mapper)((self.extractor)(&row)))
-            }
-
-            pub async fn all(self) -> Result<Vec<T>, tokio_postgres::Error> {
-                self.iter().await?.try_collect().await
-            }
-
-            pub async fn opt(self) -> Result<Option<T>, tokio_postgres::Error> {
-                let stmt = self.stmt.prepare(self.client).await?;
-                Ok(self
-                    .client
-                    .query_opt(stmt, &self.params)
-                    .await?
-                    .map(|row| (self.mapper)((self.extractor)(&row))))
-            }
-
-            pub async fn iter(
-                self,
-            ) -> Result<
-                impl futures::Stream<Item = Result<T, tokio_postgres::Error>> + 'a,
-                tokio_postgres::Error,
-            > {
-                let stmt = self.stmt.prepare(self.client).await?;
-                let it = self
-                    .client
-                    .query_raw(stmt, cornucopia_async::private::slice_iter(&self.params))
-                    .await?
-                    .map(move |res| res.map(|row| (self.mapper)((self.extractor)(&row))))
-                    .into_stream();
-                Ok(it)
-            }
-        }
-
-        pub struct SuperSuperTypesPublicCopyCompositeQuery<'a, C: GenericClient, T, const N: usize> {
-            client: &'a C,
-            params: [&'a (dyn postgres_types::ToSql + Sync); N],
-            stmt: &'a mut cornucopia_async::private::Stmt,
-            extractor: fn(&tokio_postgres::Row) -> super::super::types::public::CopyComposite,
-            mapper: fn(super::super::types::public::CopyComposite) -> T,
-        }
-        impl<'a, C, T: 'a, const N: usize> SuperSuperTypesPublicCopyCompositeQuery<'a, C, T, N>
-        where
-            C: GenericClient,
-        {
-            pub fn map<R>(
-                self,
-                mapper: fn(super::super::types::public::CopyComposite) -> R,
-            ) -> SuperSuperTypesPublicCopyCompositeQuery<'a, C, R, N> {
-                SuperSuperTypesPublicCopyCompositeQuery {
-                    client: self.client,
-                    params: self.params,
-                    stmt: self.stmt,
-                    extractor: self.extractor,
-                    mapper,
-                }
-            }
-
-            pub async fn one(self) -> Result<T, tokio_postgres::Error> {
-                let stmt = self.stmt.prepare(self.client).await?;
-                let row = self.client.query_one(stmt, &self.params).await?;
-                Ok((self.mapper)((self.extractor)(&row)))
-            }
-
-            pub async fn all(self) -> Result<Vec<T>, tokio_postgres::Error> {
-                self.iter().await?.try_collect().await
-            }
-
-            pub async fn opt(self) -> Result<Option<T>, tokio_postgres::Error> {
-                let stmt = self.stmt.prepare(self.client).await?;
-                Ok(self
-                    .client
-                    .query_opt(stmt, &self.params)
-                    .await?
-                    .map(|row| (self.mapper)((self.extractor)(&row))))
-            }
-
-            pub async fn iter(
-                self,
-            ) -> Result<
-                impl futures::Stream<Item = Result<T, tokio_postgres::Error>> + 'a,
-                tokio_postgres::Error,
-            > {
-                let stmt = self.stmt.prepare(self.client).await?;
-                let it = self
-                    .client
-                    .query_raw(stmt, cornucopia_async::private::slice_iter(&self.params))
-                    .await?
-                    .map(move |res| res.map(|row| (self.mapper)((self.extractor)(&row))))
-                    .into_stream();
-                Ok(it)
-            }
-        }
         pub fn insert_clone() -> InsertCloneStmt {
             InsertCloneStmt(cornucopia_async::private::Stmt::new(
                 "INSERT INTO clone (composite) VALUES ($1)",
@@ -994,13 +898,14 @@ pub mod queries {
             pub fn bind<'a, C: GenericClient>(
                 &'a mut self,
                 client: &'a C,
-            ) -> SuperSuperTypesPublicCloneCompositeQuery<
+            ) -> cornucopia_async::private::Query<
                 'a,
                 C,
                 super::super::types::public::CloneComposite,
+                super::super::types::public::CloneComposite,
                 0,
             > {
-                SuperSuperTypesPublicCloneCompositeQuery {
+                cornucopia_async::private::Query {
                     client,
                     params: [],
                     stmt: &mut self.0,
@@ -1033,13 +938,14 @@ pub mod queries {
             pub fn bind<'a, C: GenericClient>(
                 &'a mut self,
                 client: &'a C,
-            ) -> SuperSuperTypesPublicCopyCompositeQuery<
+            ) -> cornucopia_async::private::Query<
                 'a,
                 C,
                 super::super::types::public::CopyComposite,
+                super::super::types::public::CopyComposite,
                 0,
             > {
-                SuperSuperTypesPublicCopyCompositeQuery {
+                cornucopia_async::private::Query {
                     client,
                     params: [],
                     stmt: &mut self.0,
@@ -1099,65 +1005,10 @@ pub mod queries {
                 }
             }
         }
-        pub struct SelectNightmareDomainQuery<'a, C: GenericClient, T, const N: usize> {
-            client: &'a C,
-            params: [&'a (dyn postgres_types::ToSql + Sync); N],
-            stmt: &'a mut cornucopia_async::private::Stmt,
-            extractor: fn(&tokio_postgres::Row) -> SelectNightmareDomainBorrowed,
-            mapper: fn(SelectNightmareDomainBorrowed) -> T,
+        impl cornucopia_async::Borrow for SelectNightmareDomain {
+            type Borrow<'r> = SelectNightmareDomainBorrowed<'r>;
         }
-        impl<'a, C, T: 'a, const N: usize> SelectNightmareDomainQuery<'a, C, T, N>
-        where
-            C: GenericClient,
-        {
-            pub fn map<R>(
-                self,
-                mapper: fn(SelectNightmareDomainBorrowed) -> R,
-            ) -> SelectNightmareDomainQuery<'a, C, R, N> {
-                SelectNightmareDomainQuery {
-                    client: self.client,
-                    params: self.params,
-                    stmt: self.stmt,
-                    extractor: self.extractor,
-                    mapper,
-                }
-            }
 
-            pub async fn one(self) -> Result<T, tokio_postgres::Error> {
-                let stmt = self.stmt.prepare(self.client).await?;
-                let row = self.client.query_one(stmt, &self.params).await?;
-                Ok((self.mapper)((self.extractor)(&row)))
-            }
-
-            pub async fn all(self) -> Result<Vec<T>, tokio_postgres::Error> {
-                self.iter().await?.try_collect().await
-            }
-
-            pub async fn opt(self) -> Result<Option<T>, tokio_postgres::Error> {
-                let stmt = self.stmt.prepare(self.client).await?;
-                Ok(self
-                    .client
-                    .query_opt(stmt, &self.params)
-                    .await?
-                    .map(|row| (self.mapper)((self.extractor)(&row))))
-            }
-
-            pub async fn iter(
-                self,
-            ) -> Result<
-                impl futures::Stream<Item = Result<T, tokio_postgres::Error>> + 'a,
-                tokio_postgres::Error,
-            > {
-                let stmt = self.stmt.prepare(self.client).await?;
-                let it = self
-                    .client
-                    .query_raw(stmt, cornucopia_async::private::slice_iter(&self.params))
-                    .await?
-                    .map(move |res| res.map(|row| (self.mapper)((self.extractor)(&row))))
-                    .into_stream();
-                Ok(it)
-            }
-        }
         #[derive(serde::Serialize, Debug, Clone, PartialEq)]
         pub struct SelectNightmareDomainNull {
             pub txt: Option<String>,
@@ -1200,64 +1051,8 @@ pub mod queries {
                 }
             }
         }
-        pub struct SelectNightmareDomainNullQuery<'a, C: GenericClient, T, const N: usize> {
-            client: &'a C,
-            params: [&'a (dyn postgres_types::ToSql + Sync); N],
-            stmt: &'a mut cornucopia_async::private::Stmt,
-            extractor: fn(&tokio_postgres::Row) -> SelectNightmareDomainNullBorrowed,
-            mapper: fn(SelectNightmareDomainNullBorrowed) -> T,
-        }
-        impl<'a, C, T: 'a, const N: usize> SelectNightmareDomainNullQuery<'a, C, T, N>
-        where
-            C: GenericClient,
-        {
-            pub fn map<R>(
-                self,
-                mapper: fn(SelectNightmareDomainNullBorrowed) -> R,
-            ) -> SelectNightmareDomainNullQuery<'a, C, R, N> {
-                SelectNightmareDomainNullQuery {
-                    client: self.client,
-                    params: self.params,
-                    stmt: self.stmt,
-                    extractor: self.extractor,
-                    mapper,
-                }
-            }
-
-            pub async fn one(self) -> Result<T, tokio_postgres::Error> {
-                let stmt = self.stmt.prepare(self.client).await?;
-                let row = self.client.query_one(stmt, &self.params).await?;
-                Ok((self.mapper)((self.extractor)(&row)))
-            }
-
-            pub async fn all(self) -> Result<Vec<T>, tokio_postgres::Error> {
-                self.iter().await?.try_collect().await
-            }
-
-            pub async fn opt(self) -> Result<Option<T>, tokio_postgres::Error> {
-                let stmt = self.stmt.prepare(self.client).await?;
-                Ok(self
-                    .client
-                    .query_opt(stmt, &self.params)
-                    .await?
-                    .map(|row| (self.mapper)((self.extractor)(&row))))
-            }
-
-            pub async fn iter(
-                self,
-            ) -> Result<
-                impl futures::Stream<Item = Result<T, tokio_postgres::Error>> + 'a,
-                tokio_postgres::Error,
-            > {
-                let stmt = self.stmt.prepare(self.client).await?;
-                let it = self
-                    .client
-                    .query_raw(stmt, cornucopia_async::private::slice_iter(&self.params))
-                    .await?
-                    .map(move |res| res.map(|row| (self.mapper)((self.extractor)(&row))))
-                    .into_stream();
-                Ok(it)
-            }
+        impl cornucopia_async::Borrow for SelectNightmareDomainNull {
+            type Borrow<'r> = SelectNightmareDomainNullBorrowed<'r>;
         }
         pub fn select_nightmare_domain() -> SelectNightmareDomainStmt {
             SelectNightmareDomainStmt(cornucopia_async::private::Stmt::new(
@@ -1269,8 +1064,14 @@ pub mod queries {
             pub fn bind<'a, C: GenericClient>(
                 &'a mut self,
                 client: &'a C,
-            ) -> SelectNightmareDomainQuery<'a, C, SelectNightmareDomain, 0> {
-                SelectNightmareDomainQuery {
+            ) -> cornucopia_async::private::Query<
+                'a,
+                C,
+                SelectNightmareDomain,
+                SelectNightmareDomain,
+                0,
+            > {
+                cornucopia_async::private::Query {
                     client,
                     params: [],
                     stmt: &mut self.0,
@@ -1371,8 +1172,14 @@ pub mod queries {
             pub fn bind<'a, C: GenericClient>(
                 &'a mut self,
                 client: &'a C,
-            ) -> SelectNightmareDomainNullQuery<'a, C, SelectNightmareDomainNull, 0> {
-                SelectNightmareDomainNullQuery {
+            ) -> cornucopia_async::private::Query<
+                'a,
+                C,
+                SelectNightmareDomainNull,
+                SelectNightmareDomainNull,
+                0,
+            > {
+                cornucopia_async::private::Query {
                     client,
                     params: [],
                     stmt: &mut self.0,
@@ -1406,61 +1213,8 @@ pub mod queries {
         pub struct Id {
             pub id: i32,
         }
-        pub struct IdQuery<'a, C: GenericClient, T, const N: usize> {
-            client: &'a C,
-            params: [&'a (dyn postgres_types::ToSql + Sync); N],
-            stmt: &'a mut cornucopia_async::private::Stmt,
-            extractor: fn(&tokio_postgres::Row) -> Id,
-            mapper: fn(Id) -> T,
-        }
-        impl<'a, C, T: 'a, const N: usize> IdQuery<'a, C, T, N>
-        where
-            C: GenericClient,
-        {
-            pub fn map<R>(self, mapper: fn(Id) -> R) -> IdQuery<'a, C, R, N> {
-                IdQuery {
-                    client: self.client,
-                    params: self.params,
-                    stmt: self.stmt,
-                    extractor: self.extractor,
-                    mapper,
-                }
-            }
-
-            pub async fn one(self) -> Result<T, tokio_postgres::Error> {
-                let stmt = self.stmt.prepare(self.client).await?;
-                let row = self.client.query_one(stmt, &self.params).await?;
-                Ok((self.mapper)((self.extractor)(&row)))
-            }
-
-            pub async fn all(self) -> Result<Vec<T>, tokio_postgres::Error> {
-                self.iter().await?.try_collect().await
-            }
-
-            pub async fn opt(self) -> Result<Option<T>, tokio_postgres::Error> {
-                let stmt = self.stmt.prepare(self.client).await?;
-                Ok(self
-                    .client
-                    .query_opt(stmt, &self.params)
-                    .await?
-                    .map(|row| (self.mapper)((self.extractor)(&row))))
-            }
-
-            pub async fn iter(
-                self,
-            ) -> Result<
-                impl futures::Stream<Item = Result<T, tokio_postgres::Error>> + 'a,
-                tokio_postgres::Error,
-            > {
-                let stmt = self.stmt.prepare(self.client).await?;
-                let it = self
-                    .client
-                    .query_raw(stmt, cornucopia_async::private::slice_iter(&self.params))
-                    .await?
-                    .map(move |res| res.map(|row| (self.mapper)((self.extractor)(&row))))
-                    .into_stream();
-                Ok(it)
-            }
+        impl cornucopia_async::Borrow for Id {
+            type Borrow<'r> = Id;
         }
         #[derive(serde::Serialize, Debug, Clone, PartialEq)]
         pub struct Named {
@@ -1492,123 +1246,10 @@ pub mod queries {
                 }
             }
         }
-        pub struct NamedQuery<'a, C: GenericClient, T, const N: usize> {
-            client: &'a C,
-            params: [&'a (dyn postgres_types::ToSql + Sync); N],
-            stmt: &'a mut cornucopia_async::private::Stmt,
-            extractor: fn(&tokio_postgres::Row) -> NamedBorrowed,
-            mapper: fn(NamedBorrowed) -> T,
-        }
-        impl<'a, C, T: 'a, const N: usize> NamedQuery<'a, C, T, N>
-        where
-            C: GenericClient,
-        {
-            pub fn map<R>(self, mapper: fn(NamedBorrowed) -> R) -> NamedQuery<'a, C, R, N> {
-                NamedQuery {
-                    client: self.client,
-                    params: self.params,
-                    stmt: self.stmt,
-                    extractor: self.extractor,
-                    mapper,
-                }
-            }
-
-            pub async fn one(self) -> Result<T, tokio_postgres::Error> {
-                let stmt = self.stmt.prepare(self.client).await?;
-                let row = self.client.query_one(stmt, &self.params).await?;
-                Ok((self.mapper)((self.extractor)(&row)))
-            }
-
-            pub async fn all(self) -> Result<Vec<T>, tokio_postgres::Error> {
-                self.iter().await?.try_collect().await
-            }
-
-            pub async fn opt(self) -> Result<Option<T>, tokio_postgres::Error> {
-                let stmt = self.stmt.prepare(self.client).await?;
-                Ok(self
-                    .client
-                    .query_opt(stmt, &self.params)
-                    .await?
-                    .map(|row| (self.mapper)((self.extractor)(&row))))
-            }
-
-            pub async fn iter(
-                self,
-            ) -> Result<
-                impl futures::Stream<Item = Result<T, tokio_postgres::Error>> + 'a,
-                tokio_postgres::Error,
-            > {
-                let stmt = self.stmt.prepare(self.client).await?;
-                let it = self
-                    .client
-                    .query_raw(stmt, cornucopia_async::private::slice_iter(&self.params))
-                    .await?
-                    .map(move |res| res.map(|row| (self.mapper)((self.extractor)(&row))))
-                    .into_stream();
-                Ok(it)
-            }
+        impl cornucopia_async::Borrow for Named {
+            type Borrow<'r> = NamedBorrowed<'r>;
         }
 
-        pub struct SuperSuperTypesPublicNamedCompositeQuery<'a, C: GenericClient, T, const N: usize> {
-            client: &'a C,
-            params: [&'a (dyn postgres_types::ToSql + Sync); N],
-            stmt: &'a mut cornucopia_async::private::Stmt,
-            extractor:
-                fn(&tokio_postgres::Row) -> super::super::types::public::NamedCompositeBorrowed,
-            mapper: fn(super::super::types::public::NamedCompositeBorrowed) -> T,
-        }
-        impl<'a, C, T: 'a, const N: usize> SuperSuperTypesPublicNamedCompositeQuery<'a, C, T, N>
-        where
-            C: GenericClient,
-        {
-            pub fn map<R>(
-                self,
-                mapper: fn(super::super::types::public::NamedCompositeBorrowed) -> R,
-            ) -> SuperSuperTypesPublicNamedCompositeQuery<'a, C, R, N> {
-                SuperSuperTypesPublicNamedCompositeQuery {
-                    client: self.client,
-                    params: self.params,
-                    stmt: self.stmt,
-                    extractor: self.extractor,
-                    mapper,
-                }
-            }
-
-            pub async fn one(self) -> Result<T, tokio_postgres::Error> {
-                let stmt = self.stmt.prepare(self.client).await?;
-                let row = self.client.query_one(stmt, &self.params).await?;
-                Ok((self.mapper)((self.extractor)(&row)))
-            }
-
-            pub async fn all(self) -> Result<Vec<T>, tokio_postgres::Error> {
-                self.iter().await?.try_collect().await
-            }
-
-            pub async fn opt(self) -> Result<Option<T>, tokio_postgres::Error> {
-                let stmt = self.stmt.prepare(self.client).await?;
-                Ok(self
-                    .client
-                    .query_opt(stmt, &self.params)
-                    .await?
-                    .map(|row| (self.mapper)((self.extractor)(&row))))
-            }
-
-            pub async fn iter(
-                self,
-            ) -> Result<
-                impl futures::Stream<Item = Result<T, tokio_postgres::Error>> + 'a,
-                tokio_postgres::Error,
-            > {
-                let stmt = self.stmt.prepare(self.client).await?;
-                let it = self
-                    .client
-                    .query_raw(stmt, cornucopia_async::private::slice_iter(&self.params))
-                    .await?
-                    .map(move |res| res.map(|row| (self.mapper)((self.extractor)(&row))))
-                    .into_stream();
-                Ok(it)
-            }
-        }
         pub fn new_named_visible() -> NewNamedVisibleStmt {
             NewNamedVisibleStmt(cornucopia_async::private::Stmt::new(
                 "INSERT INTO named (name, price, show) VALUES ($1, $2, true) RETURNING id ",
@@ -1621,8 +1262,8 @@ pub mod queries {
                 client: &'a C,
                 name: &'a T1,
                 price: &'a Option<f64>,
-            ) -> IdQuery<'a, C, Id, 2> {
-                IdQuery {
+            ) -> cornucopia_async::private::Query<'a, C, Id, Id, 2> {
+                cornucopia_async::private::Query {
                     client,
                     params: [name, price],
                     stmt: &mut self.0,
@@ -1632,14 +1273,18 @@ pub mod queries {
             }
         }
         impl<'a, C: GenericClient, T1: cornucopia_async::StringSql>
-            cornucopia_async::Params<'a, NamedParams<T1>, IdQuery<'a, C, Id, 2>, C>
-            for NewNamedVisibleStmt
+            cornucopia_async::Params<
+                'a,
+                NamedParams<T1>,
+                cornucopia_async::private::Query<'a, C, Id, Id, 2>,
+                C,
+            > for NewNamedVisibleStmt
         {
             fn params(
                 &'a mut self,
                 client: &'a C,
                 params: &'a NamedParams<T1>,
-            ) -> IdQuery<'a, C, Id, 2> {
+            ) -> cornucopia_async::private::Query<'a, C, Id, Id, 2> {
                 self.bind(client, &params.name, &params.price)
             }
         }
@@ -1655,8 +1300,8 @@ pub mod queries {
                 client: &'a C,
                 price: &'a Option<f64>,
                 name: &'a T1,
-            ) -> IdQuery<'a, C, Id, 2> {
-                IdQuery {
+            ) -> cornucopia_async::private::Query<'a, C, Id, Id, 2> {
+                cornucopia_async::private::Query {
                     client,
                     params: [price, name],
                     stmt: &mut self.0,
@@ -1666,14 +1311,18 @@ pub mod queries {
             }
         }
         impl<'a, C: GenericClient, T1: cornucopia_async::StringSql>
-            cornucopia_async::Params<'a, NamedParams<T1>, IdQuery<'a, C, Id, 2>, C>
-            for NewNamedHiddenStmt
+            cornucopia_async::Params<
+                'a,
+                NamedParams<T1>,
+                cornucopia_async::private::Query<'a, C, Id, Id, 2>,
+                C,
+            > for NewNamedHiddenStmt
         {
             fn params(
                 &'a mut self,
                 client: &'a C,
                 params: &'a NamedParams<T1>,
-            ) -> IdQuery<'a, C, Id, 2> {
+            ) -> cornucopia_async::private::Query<'a, C, Id, Id, 2> {
                 self.bind(client, &params.price, &params.name)
             }
         }
@@ -1685,8 +1334,8 @@ pub mod queries {
             pub fn bind<'a, C: GenericClient>(
                 &'a mut self,
                 client: &'a C,
-            ) -> NamedQuery<'a, C, Named, 0> {
-                NamedQuery {
+            ) -> cornucopia_async::private::Query<'a, C, Named, Named, 0> {
+                cornucopia_async::private::Query {
                     client,
                     params: [],
                     stmt: &mut self.0,
@@ -1711,8 +1360,8 @@ pub mod queries {
                 &'a mut self,
                 client: &'a C,
                 id: &'a i32,
-            ) -> NamedQuery<'a, C, Named, 1> {
-                NamedQuery {
+            ) -> cornucopia_async::private::Query<'a, C, Named, Named, 1> {
+                cornucopia_async::private::Query {
                     client,
                     params: [id],
                     stmt: &mut self.0,
@@ -1777,13 +1426,14 @@ pub mod queries {
             pub fn bind<'a, C: GenericClient>(
                 &'a mut self,
                 client: &'a C,
-            ) -> SuperSuperTypesPublicNamedCompositeQuery<
+            ) -> cornucopia_async::private::Query<
                 'a,
                 C,
                 super::super::types::public::NamedComposite,
+                super::super::types::public::NamedComposite,
                 0,
             > {
-                SuperSuperTypesPublicNamedCompositeQuery {
+                cornucopia_async::private::Query {
                     client,
                     params: [],
                     stmt: &mut self.0,
@@ -1834,61 +1484,8 @@ pub mod queries {
                 }
             }
         }
-        pub struct NullityQuery<'a, C: GenericClient, T, const N: usize> {
-            client: &'a C,
-            params: [&'a (dyn postgres_types::ToSql + Sync); N],
-            stmt: &'a mut cornucopia_async::private::Stmt,
-            extractor: fn(&tokio_postgres::Row) -> NullityBorrowed,
-            mapper: fn(NullityBorrowed) -> T,
-        }
-        impl<'a, C, T: 'a, const N: usize> NullityQuery<'a, C, T, N>
-        where
-            C: GenericClient,
-        {
-            pub fn map<R>(self, mapper: fn(NullityBorrowed) -> R) -> NullityQuery<'a, C, R, N> {
-                NullityQuery {
-                    client: self.client,
-                    params: self.params,
-                    stmt: self.stmt,
-                    extractor: self.extractor,
-                    mapper,
-                }
-            }
-
-            pub async fn one(self) -> Result<T, tokio_postgres::Error> {
-                let stmt = self.stmt.prepare(self.client).await?;
-                let row = self.client.query_one(stmt, &self.params).await?;
-                Ok((self.mapper)((self.extractor)(&row)))
-            }
-
-            pub async fn all(self) -> Result<Vec<T>, tokio_postgres::Error> {
-                self.iter().await?.try_collect().await
-            }
-
-            pub async fn opt(self) -> Result<Option<T>, tokio_postgres::Error> {
-                let stmt = self.stmt.prepare(self.client).await?;
-                Ok(self
-                    .client
-                    .query_opt(stmt, &self.params)
-                    .await?
-                    .map(|row| (self.mapper)((self.extractor)(&row))))
-            }
-
-            pub async fn iter(
-                self,
-            ) -> Result<
-                impl futures::Stream<Item = Result<T, tokio_postgres::Error>> + 'a,
-                tokio_postgres::Error,
-            > {
-                let stmt = self.stmt.prepare(self.client).await?;
-                let it = self
-                    .client
-                    .query_raw(stmt, cornucopia_async::private::slice_iter(&self.params))
-                    .await?
-                    .map(move |res| res.map(|row| (self.mapper)((self.extractor)(&row))))
-                    .into_stream();
-                Ok(it)
-            }
+        impl cornucopia_async::Borrow for Nullity {
+            type Borrow<'r> = NullityBorrowed<'r>;
         }
         pub fn new_nullity() -> NewNullityStmt {
             NewNullityStmt(cornucopia_async::private::Stmt::new(
@@ -1955,8 +1552,8 @@ pub mod queries {
             pub fn bind<'a, C: GenericClient>(
                 &'a mut self,
                 client: &'a C,
-            ) -> NullityQuery<'a, C, Nullity, 0> {
-                NullityQuery {
+            ) -> cornucopia_async::private::Query<'a, C, Nullity, Nullity, 0> {
+                cornucopia_async::private::Query {
                     client,
                     params: [],
                     stmt: &mut self.0,
@@ -2005,65 +1602,10 @@ pub mod queries {
                 }
             }
         }
-        pub struct SelectBookQuery<'a, C: GenericClient, T, const N: usize> {
-            client: &'a C,
-            params: [&'a (dyn postgres_types::ToSql + Sync); N],
-            stmt: &'a mut cornucopia_async::private::Stmt,
-            extractor: fn(&tokio_postgres::Row) -> SelectBookBorrowed,
-            mapper: fn(SelectBookBorrowed) -> T,
+        impl cornucopia_async::Borrow for SelectBook {
+            type Borrow<'r> = SelectBookBorrowed<'r>;
         }
-        impl<'a, C, T: 'a, const N: usize> SelectBookQuery<'a, C, T, N>
-        where
-            C: GenericClient,
-        {
-            pub fn map<R>(
-                self,
-                mapper: fn(SelectBookBorrowed) -> R,
-            ) -> SelectBookQuery<'a, C, R, N> {
-                SelectBookQuery {
-                    client: self.client,
-                    params: self.params,
-                    stmt: self.stmt,
-                    extractor: self.extractor,
-                    mapper,
-                }
-            }
 
-            pub async fn one(self) -> Result<T, tokio_postgres::Error> {
-                let stmt = self.stmt.prepare(self.client).await?;
-                let row = self.client.query_one(stmt, &self.params).await?;
-                Ok((self.mapper)((self.extractor)(&row)))
-            }
-
-            pub async fn all(self) -> Result<Vec<T>, tokio_postgres::Error> {
-                self.iter().await?.try_collect().await
-            }
-
-            pub async fn opt(self) -> Result<Option<T>, tokio_postgres::Error> {
-                let stmt = self.stmt.prepare(self.client).await?;
-                Ok(self
-                    .client
-                    .query_opt(stmt, &self.params)
-                    .await?
-                    .map(|row| (self.mapper)((self.extractor)(&row))))
-            }
-
-            pub async fn iter(
-                self,
-            ) -> Result<
-                impl futures::Stream<Item = Result<T, tokio_postgres::Error>> + 'a,
-                tokio_postgres::Error,
-            > {
-                let stmt = self.stmt.prepare(self.client).await?;
-                let it = self
-                    .client
-                    .query_raw(stmt, cornucopia_async::private::slice_iter(&self.params))
-                    .await?
-                    .map(move |res| res.map(|row| (self.mapper)((self.extractor)(&row))))
-                    .into_stream();
-                Ok(it)
-            }
-        }
         #[derive(serde::Serialize, Debug, Clone, PartialEq)]
         pub struct FindBooks {
             pub name: String,
@@ -2081,61 +1623,8 @@ pub mod queries {
                 }
             }
         }
-        pub struct FindBooksQuery<'a, C: GenericClient, T, const N: usize> {
-            client: &'a C,
-            params: [&'a (dyn postgres_types::ToSql + Sync); N],
-            stmt: &'a mut cornucopia_async::private::Stmt,
-            extractor: fn(&tokio_postgres::Row) -> FindBooksBorrowed,
-            mapper: fn(FindBooksBorrowed) -> T,
-        }
-        impl<'a, C, T: 'a, const N: usize> FindBooksQuery<'a, C, T, N>
-        where
-            C: GenericClient,
-        {
-            pub fn map<R>(self, mapper: fn(FindBooksBorrowed) -> R) -> FindBooksQuery<'a, C, R, N> {
-                FindBooksQuery {
-                    client: self.client,
-                    params: self.params,
-                    stmt: self.stmt,
-                    extractor: self.extractor,
-                    mapper,
-                }
-            }
-
-            pub async fn one(self) -> Result<T, tokio_postgres::Error> {
-                let stmt = self.stmt.prepare(self.client).await?;
-                let row = self.client.query_one(stmt, &self.params).await?;
-                Ok((self.mapper)((self.extractor)(&row)))
-            }
-
-            pub async fn all(self) -> Result<Vec<T>, tokio_postgres::Error> {
-                self.iter().await?.try_collect().await
-            }
-
-            pub async fn opt(self) -> Result<Option<T>, tokio_postgres::Error> {
-                let stmt = self.stmt.prepare(self.client).await?;
-                Ok(self
-                    .client
-                    .query_opt(stmt, &self.params)
-                    .await?
-                    .map(|row| (self.mapper)((self.extractor)(&row))))
-            }
-
-            pub async fn iter(
-                self,
-            ) -> Result<
-                impl futures::Stream<Item = Result<T, tokio_postgres::Error>> + 'a,
-                tokio_postgres::Error,
-            > {
-                let stmt = self.stmt.prepare(self.client).await?;
-                let it = self
-                    .client
-                    .query_raw(stmt, cornucopia_async::private::slice_iter(&self.params))
-                    .await?
-                    .map(move |res| res.map(|row| (self.mapper)((self.extractor)(&row))))
-                    .into_stream();
-                Ok(it)
-            }
+        impl cornucopia_async::Borrow for FindBooks {
+            type Borrow<'r> = FindBooksBorrowed<'r>;
         }
         pub fn insert_book() -> InsertBookStmt {
             InsertBookStmt(cornucopia_async::private::Stmt::new(
@@ -2197,8 +1686,8 @@ pub mod queries {
             pub fn bind<'a, C: GenericClient>(
                 &'a mut self,
                 client: &'a C,
-            ) -> SelectBookQuery<'a, C, SelectBook, 0> {
-                SelectBookQuery {
+            ) -> cornucopia_async::private::Query<'a, C, SelectBook, SelectBook, 0> {
+                cornucopia_async::private::Query {
                     client,
                     params: [],
                     stmt: &mut self.0,
@@ -2226,8 +1715,8 @@ pub mod queries {
                 &'a mut self,
                 client: &'a C,
                 title: &'a T2,
-            ) -> FindBooksQuery<'a, C, FindBooks, 1> {
-                FindBooksQuery {
+            ) -> cornucopia_async::private::Query<'a, C, FindBooks, FindBooks, 1> {
+                cornucopia_async::private::Query {
                     client,
                     params: [title],
                     stmt: &mut self.0,
@@ -2552,65 +2041,10 @@ pub mod queries {
                 }
             }
         }
-        pub struct EverythingQuery<'a, C: GenericClient, T, const N: usize> {
-            client: &'a C,
-            params: [&'a (dyn postgres_types::ToSql + Sync); N],
-            stmt: &'a mut cornucopia_async::private::Stmt,
-            extractor: fn(&tokio_postgres::Row) -> EverythingBorrowed,
-            mapper: fn(EverythingBorrowed) -> T,
+        impl cornucopia_async::Borrow for Everything {
+            type Borrow<'r> = EverythingBorrowed<'r>;
         }
-        impl<'a, C, T: 'a, const N: usize> EverythingQuery<'a, C, T, N>
-        where
-            C: GenericClient,
-        {
-            pub fn map<R>(
-                self,
-                mapper: fn(EverythingBorrowed) -> R,
-            ) -> EverythingQuery<'a, C, R, N> {
-                EverythingQuery {
-                    client: self.client,
-                    params: self.params,
-                    stmt: self.stmt,
-                    extractor: self.extractor,
-                    mapper,
-                }
-            }
 
-            pub async fn one(self) -> Result<T, tokio_postgres::Error> {
-                let stmt = self.stmt.prepare(self.client).await?;
-                let row = self.client.query_one(stmt, &self.params).await?;
-                Ok((self.mapper)((self.extractor)(&row)))
-            }
-
-            pub async fn all(self) -> Result<Vec<T>, tokio_postgres::Error> {
-                self.iter().await?.try_collect().await
-            }
-
-            pub async fn opt(self) -> Result<Option<T>, tokio_postgres::Error> {
-                let stmt = self.stmt.prepare(self.client).await?;
-                Ok(self
-                    .client
-                    .query_opt(stmt, &self.params)
-                    .await?
-                    .map(|row| (self.mapper)((self.extractor)(&row))))
-            }
-
-            pub async fn iter(
-                self,
-            ) -> Result<
-                impl futures::Stream<Item = Result<T, tokio_postgres::Error>> + 'a,
-                tokio_postgres::Error,
-            > {
-                let stmt = self.stmt.prepare(self.client).await?;
-                let it = self
-                    .client
-                    .query_raw(stmt, cornucopia_async::private::slice_iter(&self.params))
-                    .await?
-                    .map(move |res| res.map(|row| (self.mapper)((self.extractor)(&row))))
-                    .into_stream();
-                Ok(it)
-            }
-        }
         #[derive(serde::Serialize, Debug, Clone, PartialEq)]
         pub struct EverythingNull {
             pub bool_: Option<bool>,
@@ -2757,65 +2191,10 @@ pub mod queries {
                 }
             }
         }
-        pub struct EverythingNullQuery<'a, C: GenericClient, T, const N: usize> {
-            client: &'a C,
-            params: [&'a (dyn postgres_types::ToSql + Sync); N],
-            stmt: &'a mut cornucopia_async::private::Stmt,
-            extractor: fn(&tokio_postgres::Row) -> EverythingNullBorrowed,
-            mapper: fn(EverythingNullBorrowed) -> T,
+        impl cornucopia_async::Borrow for EverythingNull {
+            type Borrow<'r> = EverythingNullBorrowed<'r>;
         }
-        impl<'a, C, T: 'a, const N: usize> EverythingNullQuery<'a, C, T, N>
-        where
-            C: GenericClient,
-        {
-            pub fn map<R>(
-                self,
-                mapper: fn(EverythingNullBorrowed) -> R,
-            ) -> EverythingNullQuery<'a, C, R, N> {
-                EverythingNullQuery {
-                    client: self.client,
-                    params: self.params,
-                    stmt: self.stmt,
-                    extractor: self.extractor,
-                    mapper,
-                }
-            }
 
-            pub async fn one(self) -> Result<T, tokio_postgres::Error> {
-                let stmt = self.stmt.prepare(self.client).await?;
-                let row = self.client.query_one(stmt, &self.params).await?;
-                Ok((self.mapper)((self.extractor)(&row)))
-            }
-
-            pub async fn all(self) -> Result<Vec<T>, tokio_postgres::Error> {
-                self.iter().await?.try_collect().await
-            }
-
-            pub async fn opt(self) -> Result<Option<T>, tokio_postgres::Error> {
-                let stmt = self.stmt.prepare(self.client).await?;
-                Ok(self
-                    .client
-                    .query_opt(stmt, &self.params)
-                    .await?
-                    .map(|row| (self.mapper)((self.extractor)(&row))))
-            }
-
-            pub async fn iter(
-                self,
-            ) -> Result<
-                impl futures::Stream<Item = Result<T, tokio_postgres::Error>> + 'a,
-                tokio_postgres::Error,
-            > {
-                let stmt = self.stmt.prepare(self.client).await?;
-                let it = self
-                    .client
-                    .query_raw(stmt, cornucopia_async::private::slice_iter(&self.params))
-                    .await?
-                    .map(move |res| res.map(|row| (self.mapper)((self.extractor)(&row))))
-                    .into_stream();
-                Ok(it)
-            }
-        }
         #[derive(serde::Serialize, Debug, Clone, PartialEq)]
         pub struct EverythingArray {
             pub bool_: Vec<bool>,
@@ -2950,65 +2329,10 @@ pub mod queries {
                 }
             }
         }
-        pub struct EverythingArrayQuery<'a, C: GenericClient, T, const N: usize> {
-            client: &'a C,
-            params: [&'a (dyn postgres_types::ToSql + Sync); N],
-            stmt: &'a mut cornucopia_async::private::Stmt,
-            extractor: fn(&tokio_postgres::Row) -> EverythingArrayBorrowed,
-            mapper: fn(EverythingArrayBorrowed) -> T,
+        impl cornucopia_async::Borrow for EverythingArray {
+            type Borrow<'r> = EverythingArrayBorrowed<'r>;
         }
-        impl<'a, C, T: 'a, const N: usize> EverythingArrayQuery<'a, C, T, N>
-        where
-            C: GenericClient,
-        {
-            pub fn map<R>(
-                self,
-                mapper: fn(EverythingArrayBorrowed) -> R,
-            ) -> EverythingArrayQuery<'a, C, R, N> {
-                EverythingArrayQuery {
-                    client: self.client,
-                    params: self.params,
-                    stmt: self.stmt,
-                    extractor: self.extractor,
-                    mapper,
-                }
-            }
 
-            pub async fn one(self) -> Result<T, tokio_postgres::Error> {
-                let stmt = self.stmt.prepare(self.client).await?;
-                let row = self.client.query_one(stmt, &self.params).await?;
-                Ok((self.mapper)((self.extractor)(&row)))
-            }
-
-            pub async fn all(self) -> Result<Vec<T>, tokio_postgres::Error> {
-                self.iter().await?.try_collect().await
-            }
-
-            pub async fn opt(self) -> Result<Option<T>, tokio_postgres::Error> {
-                let stmt = self.stmt.prepare(self.client).await?;
-                Ok(self
-                    .client
-                    .query_opt(stmt, &self.params)
-                    .await?
-                    .map(|row| (self.mapper)((self.extractor)(&row))))
-            }
-
-            pub async fn iter(
-                self,
-            ) -> Result<
-                impl futures::Stream<Item = Result<T, tokio_postgres::Error>> + 'a,
-                tokio_postgres::Error,
-            > {
-                let stmt = self.stmt.prepare(self.client).await?;
-                let it = self
-                    .client
-                    .query_raw(stmt, cornucopia_async::private::slice_iter(&self.params))
-                    .await?
-                    .map(move |res| res.map(|row| (self.mapper)((self.extractor)(&row))))
-                    .into_stream();
-                Ok(it)
-            }
-        }
         #[derive(serde::Serialize, Debug, Clone, PartialEq)]
         pub struct EverythingArrayNull {
             pub bool_: Option<Vec<bool>>,
@@ -3151,131 +2475,10 @@ pub mod queries {
                 }
             }
         }
-        pub struct EverythingArrayNullQuery<'a, C: GenericClient, T, const N: usize> {
-            client: &'a C,
-            params: [&'a (dyn postgres_types::ToSql + Sync); N],
-            stmt: &'a mut cornucopia_async::private::Stmt,
-            extractor: fn(&tokio_postgres::Row) -> EverythingArrayNullBorrowed,
-            mapper: fn(EverythingArrayNullBorrowed) -> T,
-        }
-        impl<'a, C, T: 'a, const N: usize> EverythingArrayNullQuery<'a, C, T, N>
-        where
-            C: GenericClient,
-        {
-            pub fn map<R>(
-                self,
-                mapper: fn(EverythingArrayNullBorrowed) -> R,
-            ) -> EverythingArrayNullQuery<'a, C, R, N> {
-                EverythingArrayNullQuery {
-                    client: self.client,
-                    params: self.params,
-                    stmt: self.stmt,
-                    extractor: self.extractor,
-                    mapper,
-                }
-            }
-
-            pub async fn one(self) -> Result<T, tokio_postgres::Error> {
-                let stmt = self.stmt.prepare(self.client).await?;
-                let row = self.client.query_one(stmt, &self.params).await?;
-                Ok((self.mapper)((self.extractor)(&row)))
-            }
-
-            pub async fn all(self) -> Result<Vec<T>, tokio_postgres::Error> {
-                self.iter().await?.try_collect().await
-            }
-
-            pub async fn opt(self) -> Result<Option<T>, tokio_postgres::Error> {
-                let stmt = self.stmt.prepare(self.client).await?;
-                Ok(self
-                    .client
-                    .query_opt(stmt, &self.params)
-                    .await?
-                    .map(|row| (self.mapper)((self.extractor)(&row))))
-            }
-
-            pub async fn iter(
-                self,
-            ) -> Result<
-                impl futures::Stream<Item = Result<T, tokio_postgres::Error>> + 'a,
-                tokio_postgres::Error,
-            > {
-                let stmt = self.stmt.prepare(self.client).await?;
-                let it = self
-                    .client
-                    .query_raw(stmt, cornucopia_async::private::slice_iter(&self.params))
-                    .await?
-                    .map(move |res| res.map(|row| (self.mapper)((self.extractor)(&row))))
-                    .into_stream();
-                Ok(it)
-            }
+        impl cornucopia_async::Borrow for EverythingArrayNull {
+            type Borrow<'r> = EverythingArrayNullBorrowed<'r>;
         }
 
-        pub struct SuperSuperTypesPublicNightmareCompositeQuery<
-            'a,
-            C: GenericClient,
-            T,
-            const N: usize,
-        > {
-            client: &'a C,
-            params: [&'a (dyn postgres_types::ToSql + Sync); N],
-            stmt: &'a mut cornucopia_async::private::Stmt,
-            extractor:
-                fn(&tokio_postgres::Row) -> super::super::types::public::NightmareCompositeBorrowed,
-            mapper: fn(super::super::types::public::NightmareCompositeBorrowed) -> T,
-        }
-        impl<'a, C, T: 'a, const N: usize> SuperSuperTypesPublicNightmareCompositeQuery<'a, C, T, N>
-        where
-            C: GenericClient,
-        {
-            pub fn map<R>(
-                self,
-                mapper: fn(super::super::types::public::NightmareCompositeBorrowed) -> R,
-            ) -> SuperSuperTypesPublicNightmareCompositeQuery<'a, C, R, N> {
-                SuperSuperTypesPublicNightmareCompositeQuery {
-                    client: self.client,
-                    params: self.params,
-                    stmt: self.stmt,
-                    extractor: self.extractor,
-                    mapper,
-                }
-            }
-
-            pub async fn one(self) -> Result<T, tokio_postgres::Error> {
-                let stmt = self.stmt.prepare(self.client).await?;
-                let row = self.client.query_one(stmt, &self.params).await?;
-                Ok((self.mapper)((self.extractor)(&row)))
-            }
-
-            pub async fn all(self) -> Result<Vec<T>, tokio_postgres::Error> {
-                self.iter().await?.try_collect().await
-            }
-
-            pub async fn opt(self) -> Result<Option<T>, tokio_postgres::Error> {
-                let stmt = self.stmt.prepare(self.client).await?;
-                Ok(self
-                    .client
-                    .query_opt(stmt, &self.params)
-                    .await?
-                    .map(|row| (self.mapper)((self.extractor)(&row))))
-            }
-
-            pub async fn iter(
-                self,
-            ) -> Result<
-                impl futures::Stream<Item = Result<T, tokio_postgres::Error>> + 'a,
-                tokio_postgres::Error,
-            > {
-                let stmt = self.stmt.prepare(self.client).await?;
-                let it = self
-                    .client
-                    .query_raw(stmt, cornucopia_async::private::slice_iter(&self.params))
-                    .await?
-                    .map(move |res| res.map(|row| (self.mapper)((self.extractor)(&row))))
-                    .into_stream();
-                Ok(it)
-            }
-        }
         pub fn select_everything() -> SelectEverythingStmt {
             SelectEverythingStmt(cornucopia_async::private::Stmt::new(
                 "SELECT * FROM Everything",
@@ -3286,8 +2489,8 @@ pub mod queries {
             pub fn bind<'a, C: GenericClient>(
                 &'a mut self,
                 client: &'a C,
-            ) -> EverythingQuery<'a, C, Everything, 0> {
-                EverythingQuery {
+            ) -> cornucopia_async::private::Query<'a, C, Everything, Everything, 0> {
+                cornucopia_async::private::Query {
                     client,
                     params: [],
                     stmt: &mut self.0,
@@ -3340,8 +2543,9 @@ pub mod queries {
             pub fn bind<'a, C: GenericClient>(
                 &'a mut self,
                 client: &'a C,
-            ) -> EverythingNullQuery<'a, C, EverythingNull, 0> {
-                EverythingNullQuery {
+            ) -> cornucopia_async::private::Query<'a, C, EverythingNull, EverythingNull, 0>
+            {
+                cornucopia_async::private::Query {
                     client,
                     params: [],
                     stmt: &mut self.0,
@@ -3556,8 +2760,9 @@ pub mod queries {
             pub fn bind<'a, C: GenericClient>(
                 &'a mut self,
                 client: &'a C,
-            ) -> EverythingArrayQuery<'a, C, EverythingArray, 0> {
-                EverythingArrayQuery {
+            ) -> cornucopia_async::private::Query<'a, C, EverythingArray, EverythingArray, 0>
+            {
+                cornucopia_async::private::Query {
                     client,
                     params: [],
                     stmt: &mut self.0,
@@ -3604,8 +2809,9 @@ pub mod queries {
             pub fn bind<'a, C: GenericClient>(
                 &'a mut self,
                 client: &'a C,
-            ) -> EverythingArrayNullQuery<'a, C, EverythingArrayNull, 0> {
-                EverythingArrayNullQuery {
+            ) -> cornucopia_async::private::Query<'a, C, EverythingArrayNull, EverythingArrayNull, 0>
+            {
+                cornucopia_async::private::Query {
                     client,
                     params: [],
                     stmt: &mut self.0,
@@ -3916,13 +3122,14 @@ pub mod queries {
             pub fn bind<'a, C: GenericClient>(
                 &'a mut self,
                 client: &'a C,
-            ) -> SuperSuperTypesPublicNightmareCompositeQuery<
+            ) -> cornucopia_async::private::Query<
                 'a,
                 C,
                 super::super::types::public::NightmareComposite,
+                super::super::types::public::NightmareComposite,
                 0,
             > {
-                SuperSuperTypesPublicNightmareCompositeQuery {
+                cornucopia_async::private::Query {
                     client,
                     params: [],
                     stmt: &mut self.0,
@@ -3973,242 +3180,19 @@ pub mod queries {
             pub price: f64,
         }
 
-        pub struct SuperSuperTypesPublicCloneCompositeQuery<'a, C: GenericClient, T, const N: usize> {
-            client: &'a C,
-            params: [&'a (dyn postgres_types::ToSql + Sync); N],
-            stmt: &'a mut cornucopia_async::private::Stmt,
-            extractor:
-                fn(&tokio_postgres::Row) -> super::super::types::public::CloneCompositeBorrowed,
-            mapper: fn(super::super::types::public::CloneCompositeBorrowed) -> T,
-        }
-        impl<'a, C, T: 'a, const N: usize> SuperSuperTypesPublicCloneCompositeQuery<'a, C, T, N>
-        where
-            C: GenericClient,
-        {
-            pub fn map<R>(
-                self,
-                mapper: fn(super::super::types::public::CloneCompositeBorrowed) -> R,
-            ) -> SuperSuperTypesPublicCloneCompositeQuery<'a, C, R, N> {
-                SuperSuperTypesPublicCloneCompositeQuery {
-                    client: self.client,
-                    params: self.params,
-                    stmt: self.stmt,
-                    extractor: self.extractor,
-                    mapper,
-                }
-            }
-
-            pub async fn one(self) -> Result<T, tokio_postgres::Error> {
-                let stmt = self.stmt.prepare(self.client).await?;
-                let row = self.client.query_one(stmt, &self.params).await?;
-                Ok((self.mapper)((self.extractor)(&row)))
-            }
-
-            pub async fn all(self) -> Result<Vec<T>, tokio_postgres::Error> {
-                self.iter().await?.try_collect().await
-            }
-
-            pub async fn opt(self) -> Result<Option<T>, tokio_postgres::Error> {
-                let stmt = self.stmt.prepare(self.client).await?;
-                Ok(self
-                    .client
-                    .query_opt(stmt, &self.params)
-                    .await?
-                    .map(|row| (self.mapper)((self.extractor)(&row))))
-            }
-
-            pub async fn iter(
-                self,
-            ) -> Result<
-                impl futures::Stream<Item = Result<T, tokio_postgres::Error>> + 'a,
-                tokio_postgres::Error,
-            > {
-                let stmt = self.stmt.prepare(self.client).await?;
-                let it = self
-                    .client
-                    .query_raw(stmt, cornucopia_async::private::slice_iter(&self.params))
-                    .await?
-                    .map(move |res| res.map(|row| (self.mapper)((self.extractor)(&row))))
-                    .into_stream();
-                Ok(it)
-            }
-        }
-
-        pub struct Optioni32Query<'a, C: GenericClient, T, const N: usize> {
-            client: &'a C,
-            params: [&'a (dyn postgres_types::ToSql + Sync); N],
-            stmt: &'a mut cornucopia_async::private::Stmt,
-            extractor: fn(&tokio_postgres::Row) -> Option<i32>,
-            mapper: fn(Option<i32>) -> T,
-        }
-        impl<'a, C, T: 'a, const N: usize> Optioni32Query<'a, C, T, N>
-        where
-            C: GenericClient,
-        {
-            pub fn map<R>(self, mapper: fn(Option<i32>) -> R) -> Optioni32Query<'a, C, R, N> {
-                Optioni32Query {
-                    client: self.client,
-                    params: self.params,
-                    stmt: self.stmt,
-                    extractor: self.extractor,
-                    mapper,
-                }
-            }
-
-            pub async fn one(self) -> Result<T, tokio_postgres::Error> {
-                let stmt = self.stmt.prepare(self.client).await?;
-                let row = self.client.query_one(stmt, &self.params).await?;
-                Ok((self.mapper)((self.extractor)(&row)))
-            }
-
-            pub async fn all(self) -> Result<Vec<T>, tokio_postgres::Error> {
-                self.iter().await?.try_collect().await
-            }
-
-            pub async fn opt(self) -> Result<Option<T>, tokio_postgres::Error> {
-                let stmt = self.stmt.prepare(self.client).await?;
-                Ok(self
-                    .client
-                    .query_opt(stmt, &self.params)
-                    .await?
-                    .map(|row| (self.mapper)((self.extractor)(&row))))
-            }
-
-            pub async fn iter(
-                self,
-            ) -> Result<
-                impl futures::Stream<Item = Result<T, tokio_postgres::Error>> + 'a,
-                tokio_postgres::Error,
-            > {
-                let stmt = self.stmt.prepare(self.client).await?;
-                let it = self
-                    .client
-                    .query_raw(stmt, cornucopia_async::private::slice_iter(&self.params))
-                    .await?
-                    .map(move |res| res.map(|row| (self.mapper)((self.extractor)(&row))))
-                    .into_stream();
-                Ok(it)
-            }
-        }
         #[derive(serde::Serialize, Debug, Clone, PartialEq, Copy)]
         pub struct Row {
             pub id: i32,
         }
-        pub struct RowQuery<'a, C: GenericClient, T, const N: usize> {
-            client: &'a C,
-            params: [&'a (dyn postgres_types::ToSql + Sync); N],
-            stmt: &'a mut cornucopia_async::private::Stmt,
-            extractor: fn(&tokio_postgres::Row) -> Row,
-            mapper: fn(Row) -> T,
-        }
-        impl<'a, C, T: 'a, const N: usize> RowQuery<'a, C, T, N>
-        where
-            C: GenericClient,
-        {
-            pub fn map<R>(self, mapper: fn(Row) -> R) -> RowQuery<'a, C, R, N> {
-                RowQuery {
-                    client: self.client,
-                    params: self.params,
-                    stmt: self.stmt,
-                    extractor: self.extractor,
-                    mapper,
-                }
-            }
-
-            pub async fn one(self) -> Result<T, tokio_postgres::Error> {
-                let stmt = self.stmt.prepare(self.client).await?;
-                let row = self.client.query_one(stmt, &self.params).await?;
-                Ok((self.mapper)((self.extractor)(&row)))
-            }
-
-            pub async fn all(self) -> Result<Vec<T>, tokio_postgres::Error> {
-                self.iter().await?.try_collect().await
-            }
-
-            pub async fn opt(self) -> Result<Option<T>, tokio_postgres::Error> {
-                let stmt = self.stmt.prepare(self.client).await?;
-                Ok(self
-                    .client
-                    .query_opt(stmt, &self.params)
-                    .await?
-                    .map(|row| (self.mapper)((self.extractor)(&row))))
-            }
-
-            pub async fn iter(
-                self,
-            ) -> Result<
-                impl futures::Stream<Item = Result<T, tokio_postgres::Error>> + 'a,
-                tokio_postgres::Error,
-            > {
-                let stmt = self.stmt.prepare(self.client).await?;
-                let it = self
-                    .client
-                    .query_raw(stmt, cornucopia_async::private::slice_iter(&self.params))
-                    .await?
-                    .map(move |res| res.map(|row| (self.mapper)((self.extractor)(&row))))
-                    .into_stream();
-                Ok(it)
-            }
+        impl cornucopia_async::Borrow for Row {
+            type Borrow<'r> = Row;
         }
         #[derive(serde::Serialize, Debug, Clone, PartialEq, Copy)]
         pub struct RowSpace {
             pub id: i32,
         }
-        pub struct RowSpaceQuery<'a, C: GenericClient, T, const N: usize> {
-            client: &'a C,
-            params: [&'a (dyn postgres_types::ToSql + Sync); N],
-            stmt: &'a mut cornucopia_async::private::Stmt,
-            extractor: fn(&tokio_postgres::Row) -> RowSpace,
-            mapper: fn(RowSpace) -> T,
-        }
-        impl<'a, C, T: 'a, const N: usize> RowSpaceQuery<'a, C, T, N>
-        where
-            C: GenericClient,
-        {
-            pub fn map<R>(self, mapper: fn(RowSpace) -> R) -> RowSpaceQuery<'a, C, R, N> {
-                RowSpaceQuery {
-                    client: self.client,
-                    params: self.params,
-                    stmt: self.stmt,
-                    extractor: self.extractor,
-                    mapper,
-                }
-            }
-
-            pub async fn one(self) -> Result<T, tokio_postgres::Error> {
-                let stmt = self.stmt.prepare(self.client).await?;
-                let row = self.client.query_one(stmt, &self.params).await?;
-                Ok((self.mapper)((self.extractor)(&row)))
-            }
-
-            pub async fn all(self) -> Result<Vec<T>, tokio_postgres::Error> {
-                self.iter().await?.try_collect().await
-            }
-
-            pub async fn opt(self) -> Result<Option<T>, tokio_postgres::Error> {
-                let stmt = self.stmt.prepare(self.client).await?;
-                Ok(self
-                    .client
-                    .query_opt(stmt, &self.params)
-                    .await?
-                    .map(|row| (self.mapper)((self.extractor)(&row))))
-            }
-
-            pub async fn iter(
-                self,
-            ) -> Result<
-                impl futures::Stream<Item = Result<T, tokio_postgres::Error>> + 'a,
-                tokio_postgres::Error,
-            > {
-                let stmt = self.stmt.prepare(self.client).await?;
-                let it = self
-                    .client
-                    .query_raw(stmt, cornucopia_async::private::slice_iter(&self.params))
-                    .await?
-                    .map(move |res| res.map(|row| (self.mapper)((self.extractor)(&row))))
-                    .into_stream();
-                Ok(it)
-            }
+        impl cornucopia_async::Borrow for RowSpace {
+            type Borrow<'r> = RowSpace;
         }
         #[derive(serde::Serialize, Debug, Clone, PartialEq)]
         pub struct Syntax {
@@ -4227,61 +3211,8 @@ pub mod queries {
                 }
             }
         }
-        pub struct SyntaxQuery<'a, C: GenericClient, T, const N: usize> {
-            client: &'a C,
-            params: [&'a (dyn postgres_types::ToSql + Sync); N],
-            stmt: &'a mut cornucopia_async::private::Stmt,
-            extractor: fn(&tokio_postgres::Row) -> SyntaxBorrowed,
-            mapper: fn(SyntaxBorrowed) -> T,
-        }
-        impl<'a, C, T: 'a, const N: usize> SyntaxQuery<'a, C, T, N>
-        where
-            C: GenericClient,
-        {
-            pub fn map<R>(self, mapper: fn(SyntaxBorrowed) -> R) -> SyntaxQuery<'a, C, R, N> {
-                SyntaxQuery {
-                    client: self.client,
-                    params: self.params,
-                    stmt: self.stmt,
-                    extractor: self.extractor,
-                    mapper,
-                }
-            }
-
-            pub async fn one(self) -> Result<T, tokio_postgres::Error> {
-                let stmt = self.stmt.prepare(self.client).await?;
-                let row = self.client.query_one(stmt, &self.params).await?;
-                Ok((self.mapper)((self.extractor)(&row)))
-            }
-
-            pub async fn all(self) -> Result<Vec<T>, tokio_postgres::Error> {
-                self.iter().await?.try_collect().await
-            }
-
-            pub async fn opt(self) -> Result<Option<T>, tokio_postgres::Error> {
-                let stmt = self.stmt.prepare(self.client).await?;
-                Ok(self
-                    .client
-                    .query_opt(stmt, &self.params)
-                    .await?
-                    .map(|row| (self.mapper)((self.extractor)(&row))))
-            }
-
-            pub async fn iter(
-                self,
-            ) -> Result<
-                impl futures::Stream<Item = Result<T, tokio_postgres::Error>> + 'a,
-                tokio_postgres::Error,
-            > {
-                let stmt = self.stmt.prepare(self.client).await?;
-                let it = self
-                    .client
-                    .query_raw(stmt, cornucopia_async::private::slice_iter(&self.params))
-                    .await?
-                    .map(move |res| res.map(|row| (self.mapper)((self.extractor)(&row))))
-                    .into_stream();
-                Ok(it)
-            }
+        impl cornucopia_async::Borrow for Syntax {
+            type Borrow<'r> = SyntaxBorrowed<'r>;
         }
         pub fn select_compact() -> SelectCompactStmt {
             SelectCompactStmt(cornucopia_async::private::Stmt::new("SELECT * FROM clone"))
@@ -4291,13 +3222,14 @@ pub mod queries {
             pub fn bind<'a, C: GenericClient>(
                 &'a mut self,
                 client: &'a C,
-            ) -> SuperSuperTypesPublicCloneCompositeQuery<
+            ) -> cornucopia_async::private::Query<
                 'a,
                 C,
                 super::super::types::public::CloneComposite,
+                super::super::types::public::CloneComposite,
                 0,
             > {
-                SuperSuperTypesPublicCloneCompositeQuery {
+                cornucopia_async::private::Query {
                     client,
                     params: [],
                     stmt: &mut self.0,
@@ -4316,13 +3248,14 @@ pub mod queries {
             pub fn bind<'a, C: GenericClient>(
                 &'a mut self,
                 client: &'a C,
-            ) -> SuperSuperTypesPublicCloneCompositeQuery<
+            ) -> cornucopia_async::private::Query<
                 'a,
                 C,
                 super::super::types::public::CloneComposite,
+                super::super::types::public::CloneComposite,
                 0,
             > {
-                SuperSuperTypesPublicCloneCompositeQuery {
+                cornucopia_async::private::Query {
                     client,
                     params: [],
                     stmt: &mut self.0,
@@ -4343,8 +3276,8 @@ pub mod queries {
                 client: &'a C,
                 name: &'a Option<T1>,
                 price: &'a Option<f64>,
-            ) -> Optioni32Query<'a, C, Option<i32>, 2> {
-                Optioni32Query {
+            ) -> cornucopia_async::private::Query<'a, C, Option<i32>, Option<i32>, 2> {
+                cornucopia_async::private::Query {
                     client,
                     params: [name, price],
                     stmt: &mut self.0,
@@ -4357,7 +3290,7 @@ pub mod queries {
             cornucopia_async::Params<
                 'a,
                 ImplicitCompactParams<T1>,
-                Optioni32Query<'a, C, Option<i32>, 2>,
+                cornucopia_async::private::Query<'a, C, Option<i32>, Option<i32>, 2>,
                 C,
             > for ImplicitCompactStmt
         {
@@ -4365,7 +3298,7 @@ pub mod queries {
                 &'a mut self,
                 client: &'a C,
                 params: &'a ImplicitCompactParams<T1>,
-            ) -> Optioni32Query<'a, C, Option<i32>, 2> {
+            ) -> cornucopia_async::private::Query<'a, C, Option<i32>, Option<i32>, 2> {
                 self.bind(client, &params.name, &params.price)
             }
         }
@@ -4381,8 +3314,8 @@ pub mod queries {
                 client: &'a C,
                 name: &'a Option<T1>,
                 price: &'a Option<f64>,
-            ) -> Optioni32Query<'a, C, Option<i32>, 2> {
-                Optioni32Query {
+            ) -> cornucopia_async::private::Query<'a, C, Option<i32>, Option<i32>, 2> {
+                cornucopia_async::private::Query {
                     client,
                     params: [name, price],
                     stmt: &mut self.0,
@@ -4395,7 +3328,7 @@ pub mod queries {
             cornucopia_async::Params<
                 'a,
                 ImplicitSpacedParams<T1>,
-                Optioni32Query<'a, C, Option<i32>, 2>,
+                cornucopia_async::private::Query<'a, C, Option<i32>, Option<i32>, 2>,
                 C,
             > for ImplicitSpacedStmt
         {
@@ -4403,7 +3336,7 @@ pub mod queries {
                 &'a mut self,
                 client: &'a C,
                 params: &'a ImplicitSpacedParams<T1>,
-            ) -> Optioni32Query<'a, C, Option<i32>, 2> {
+            ) -> cornucopia_async::private::Query<'a, C, Option<i32>, Option<i32>, 2> {
                 self.bind(client, &params.name, &params.price)
             }
         }
@@ -4419,8 +3352,8 @@ pub mod queries {
                 client: &'a C,
                 name: &'a T1,
                 price: &'a f64,
-            ) -> RowQuery<'a, C, Row, 2> {
-                RowQuery {
+            ) -> cornucopia_async::private::Query<'a, C, Row, Row, 2> {
+                cornucopia_async::private::Query {
                     client,
                     params: [name, price],
                     stmt: &mut self.0,
@@ -4430,14 +3363,18 @@ pub mod queries {
             }
         }
         impl<'a, C: GenericClient, T1: cornucopia_async::StringSql>
-            cornucopia_async::Params<'a, Params<T1>, RowQuery<'a, C, Row, 2>, C>
-            for NamedCompactStmt
+            cornucopia_async::Params<
+                'a,
+                Params<T1>,
+                cornucopia_async::private::Query<'a, C, Row, Row, 2>,
+                C,
+            > for NamedCompactStmt
         {
             fn params(
                 &'a mut self,
                 client: &'a C,
                 params: &'a Params<T1>,
-            ) -> RowQuery<'a, C, Row, 2> {
+            ) -> cornucopia_async::private::Query<'a, C, Row, Row, 2> {
                 self.bind(client, &params.name, &params.price)
             }
         }
@@ -4453,8 +3390,8 @@ pub mod queries {
                 client: &'a C,
                 name: &'a T1,
                 price: &'a f64,
-            ) -> RowSpaceQuery<'a, C, RowSpace, 2> {
-                RowSpaceQuery {
+            ) -> cornucopia_async::private::Query<'a, C, RowSpace, RowSpace, 2> {
+                cornucopia_async::private::Query {
                     client,
                     params: [name, price],
                     stmt: &mut self.0,
@@ -4464,14 +3401,18 @@ pub mod queries {
             }
         }
         impl<'a, C: GenericClient, T1: cornucopia_async::StringSql>
-            cornucopia_async::Params<'a, ParamsSpace<T1>, RowSpaceQuery<'a, C, RowSpace, 2>, C>
-            for NamedSpacedStmt
+            cornucopia_async::Params<
+                'a,
+                ParamsSpace<T1>,
+                cornucopia_async::private::Query<'a, C, RowSpace, RowSpace, 2>,
+                C,
+            > for NamedSpacedStmt
         {
             fn params(
                 &'a mut self,
                 client: &'a C,
                 params: &'a ParamsSpace<T1>,
-            ) -> RowSpaceQuery<'a, C, RowSpace, 2> {
+            ) -> cornucopia_async::private::Query<'a, C, RowSpace, RowSpace, 2> {
                 self.bind(client, &params.name, &params.price)
             }
         }
@@ -4629,8 +3570,8 @@ pub mod queries {
             pub fn bind<'a, C: GenericClient>(
                 &'a mut self,
                 client: &'a C,
-            ) -> SyntaxQuery<'a, C, Syntax, 0> {
-                SyntaxQuery {
+            ) -> cornucopia_async::private::Query<'a, C, Syntax, Syntax, 0> {
+                cornucopia_async::private::Query {
                     client,
                     params: [],
                     stmt: &mut self.0,

--- a/codegen_test/src/cornucopia_sync.rs
+++ b/codegen_test/src/cornucopia_sync.rs
@@ -25,6 +25,9 @@ pub mod types {
                 }
             }
         }
+        impl cornucopia_sync::Borrow for CloneComposite {
+            type Borrow<'r> = CloneCompositeBorrowed<'r>;
+        }
         impl<'a> postgres_types::FromSql<'a> for CloneCompositeBorrowed<'a> {
             fn from_sql(
                 ty: &postgres_types::Type,
@@ -180,6 +183,9 @@ pub mod types {
                 postgres_types::__to_sql_checked(self, ty, out)
             }
         }
+        impl cornucopia_sync::Borrow for CopyComposite {
+            type Borrow<'r> = CopyComposite;
+        }
         #[derive(serde::Serialize, Debug, postgres_types::FromSql, Clone, PartialEq)]
         #[postgres(name = "domain_composite")]
         pub struct DomainComposite {
@@ -211,6 +217,9 @@ pub mod types {
                         .collect(),
                 }
             }
+        }
+        impl cornucopia_sync::Borrow for DomainComposite {
+            type Borrow<'r> = DomainCompositeBorrowed<'r>;
         }
         impl<'a> postgres_types::FromSql<'a> for DomainCompositeBorrowed<'a> {
             fn from_sql(
@@ -350,6 +359,9 @@ pub mod types {
                 }
             }
         }
+        impl cornucopia_sync::Borrow for NamedComposite {
+            type Borrow<'r> = NamedCompositeBorrowed<'r>;
+        }
         impl<'a> postgres_types::FromSql<'a> for NamedCompositeBorrowed<'a> {
             fn from_sql(
                 ty: &postgres_types::Type,
@@ -463,6 +475,9 @@ pub mod types {
                 }
             }
         }
+        impl cornucopia_sync::Borrow for NullityComposite {
+            type Borrow<'r> = NullityCompositeBorrowed<'r>;
+        }
         impl<'a> postgres_types::FromSql<'a> for NullityCompositeBorrowed<'a> {
             fn from_sql(
                 ty: &postgres_types::Type,
@@ -570,6 +585,9 @@ pub mod types {
             Patrick,
             Squidward,
         }
+        impl cornucopia_sync::Borrow for SpongebobCharacter {
+            type Borrow<'r> = SpongebobCharacter;
+        }
         #[derive(serde::Serialize, Debug, postgres_types::FromSql, Clone, PartialEq)]
         #[postgres(name = "custom_composite")]
         pub struct CustomComposite {
@@ -597,6 +615,9 @@ pub mod types {
                     nice,
                 }
             }
+        }
+        impl cornucopia_sync::Borrow for CustomComposite {
+            type Borrow<'r> = CustomCompositeBorrowed<'r>;
         }
         impl<'a> postgres_types::FromSql<'a> for CustomCompositeBorrowed<'a> {
             fn from_sql(
@@ -728,6 +749,9 @@ pub mod types {
                 }
             }
         }
+        impl cornucopia_sync::Borrow for NightmareComposite {
+            type Borrow<'r> = NightmareCompositeBorrowed<'r>;
+        }
         impl<'a> postgres_types::FromSql<'a> for NightmareCompositeBorrowed<'a> {
             fn from_sql(
                 ty: &postgres_types::Type,
@@ -846,117 +870,6 @@ pub mod queries {
     pub mod copy {
         use postgres::{fallible_iterator::FallibleIterator, GenericClient};
 
-        pub struct SuperSuperTypesPublicCloneCompositeQuery<'a, C: GenericClient, T, const N: usize> {
-            client: &'a mut C,
-            params: [&'a (dyn postgres_types::ToSql + Sync); N],
-            stmt: &'a mut cornucopia_sync::private::Stmt,
-            extractor: fn(&postgres::Row) -> super::super::types::public::CloneCompositeBorrowed,
-            mapper: fn(super::super::types::public::CloneCompositeBorrowed) -> T,
-        }
-        impl<'a, C, T: 'a, const N: usize> SuperSuperTypesPublicCloneCompositeQuery<'a, C, T, N>
-        where
-            C: GenericClient,
-        {
-            pub fn map<R>(
-                self,
-                mapper: fn(super::super::types::public::CloneCompositeBorrowed) -> R,
-            ) -> SuperSuperTypesPublicCloneCompositeQuery<'a, C, R, N> {
-                SuperSuperTypesPublicCloneCompositeQuery {
-                    client: self.client,
-                    params: self.params,
-                    stmt: self.stmt,
-                    extractor: self.extractor,
-                    mapper,
-                }
-            }
-
-            pub fn one(self) -> Result<T, postgres::Error> {
-                let stmt = self.stmt.prepare(self.client)?;
-                let row = self.client.query_one(stmt, &self.params)?;
-                Ok((self.mapper)((self.extractor)(&row)))
-            }
-
-            pub fn all(self) -> Result<Vec<T>, postgres::Error> {
-                self.iter()?.collect()
-            }
-
-            pub fn opt(self) -> Result<Option<T>, postgres::Error> {
-                let stmt = self.stmt.prepare(self.client)?;
-                Ok(self
-                    .client
-                    .query_opt(stmt, &self.params)?
-                    .map(|row| (self.mapper)((self.extractor)(&row))))
-            }
-
-            pub fn iter(
-                self,
-            ) -> Result<impl Iterator<Item = Result<T, postgres::Error>> + 'a, postgres::Error>
-            {
-                let stmt = self.stmt.prepare(self.client)?;
-                let it = self
-                    .client
-                    .query_raw(stmt, cornucopia_sync::private::slice_iter(&self.params))?
-                    .iterator()
-                    .map(move |res| res.map(|row| (self.mapper)((self.extractor)(&row))));
-                Ok(it)
-            }
-        }
-
-        pub struct SuperSuperTypesPublicCopyCompositeQuery<'a, C: GenericClient, T, const N: usize> {
-            client: &'a mut C,
-            params: [&'a (dyn postgres_types::ToSql + Sync); N],
-            stmt: &'a mut cornucopia_sync::private::Stmt,
-            extractor: fn(&postgres::Row) -> super::super::types::public::CopyComposite,
-            mapper: fn(super::super::types::public::CopyComposite) -> T,
-        }
-        impl<'a, C, T: 'a, const N: usize> SuperSuperTypesPublicCopyCompositeQuery<'a, C, T, N>
-        where
-            C: GenericClient,
-        {
-            pub fn map<R>(
-                self,
-                mapper: fn(super::super::types::public::CopyComposite) -> R,
-            ) -> SuperSuperTypesPublicCopyCompositeQuery<'a, C, R, N> {
-                SuperSuperTypesPublicCopyCompositeQuery {
-                    client: self.client,
-                    params: self.params,
-                    stmt: self.stmt,
-                    extractor: self.extractor,
-                    mapper,
-                }
-            }
-
-            pub fn one(self) -> Result<T, postgres::Error> {
-                let stmt = self.stmt.prepare(self.client)?;
-                let row = self.client.query_one(stmt, &self.params)?;
-                Ok((self.mapper)((self.extractor)(&row)))
-            }
-
-            pub fn all(self) -> Result<Vec<T>, postgres::Error> {
-                self.iter()?.collect()
-            }
-
-            pub fn opt(self) -> Result<Option<T>, postgres::Error> {
-                let stmt = self.stmt.prepare(self.client)?;
-                Ok(self
-                    .client
-                    .query_opt(stmt, &self.params)?
-                    .map(|row| (self.mapper)((self.extractor)(&row))))
-            }
-
-            pub fn iter(
-                self,
-            ) -> Result<impl Iterator<Item = Result<T, postgres::Error>> + 'a, postgres::Error>
-            {
-                let stmt = self.stmt.prepare(self.client)?;
-                let it = self
-                    .client
-                    .query_raw(stmt, cornucopia_sync::private::slice_iter(&self.params))?
-                    .iterator()
-                    .map(move |res| res.map(|row| (self.mapper)((self.extractor)(&row))));
-                Ok(it)
-            }
-        }
         pub fn insert_clone() -> InsertCloneStmt {
             InsertCloneStmt(cornucopia_sync::private::Stmt::new(
                 "INSERT INTO clone (composite) VALUES ($1)",
@@ -981,13 +894,14 @@ pub mod queries {
             pub fn bind<'a, C: GenericClient>(
                 &'a mut self,
                 client: &'a mut C,
-            ) -> SuperSuperTypesPublicCloneCompositeQuery<
+            ) -> cornucopia_sync::private::Query<
                 'a,
                 C,
                 super::super::types::public::CloneComposite,
+                super::super::types::public::CloneComposite,
                 0,
             > {
-                SuperSuperTypesPublicCloneCompositeQuery {
+                cornucopia_sync::private::Query {
                     client,
                     params: [],
                     stmt: &mut self.0,
@@ -1020,13 +934,14 @@ pub mod queries {
             pub fn bind<'a, C: GenericClient>(
                 &'a mut self,
                 client: &'a mut C,
-            ) -> SuperSuperTypesPublicCopyCompositeQuery<
+            ) -> cornucopia_sync::private::Query<
                 'a,
                 C,
                 super::super::types::public::CopyComposite,
+                super::super::types::public::CopyComposite,
                 0,
             > {
-                SuperSuperTypesPublicCopyCompositeQuery {
+                cornucopia_sync::private::Query {
                     client,
                     params: [],
                     stmt: &mut self.0,
@@ -1084,61 +999,10 @@ pub mod queries {
                 }
             }
         }
-        pub struct SelectNightmareDomainQuery<'a, C: GenericClient, T, const N: usize> {
-            client: &'a mut C,
-            params: [&'a (dyn postgres_types::ToSql + Sync); N],
-            stmt: &'a mut cornucopia_sync::private::Stmt,
-            extractor: fn(&postgres::Row) -> SelectNightmareDomainBorrowed,
-            mapper: fn(SelectNightmareDomainBorrowed) -> T,
+        impl cornucopia_sync::Borrow for SelectNightmareDomain {
+            type Borrow<'r> = SelectNightmareDomainBorrowed<'r>;
         }
-        impl<'a, C, T: 'a, const N: usize> SelectNightmareDomainQuery<'a, C, T, N>
-        where
-            C: GenericClient,
-        {
-            pub fn map<R>(
-                self,
-                mapper: fn(SelectNightmareDomainBorrowed) -> R,
-            ) -> SelectNightmareDomainQuery<'a, C, R, N> {
-                SelectNightmareDomainQuery {
-                    client: self.client,
-                    params: self.params,
-                    stmt: self.stmt,
-                    extractor: self.extractor,
-                    mapper,
-                }
-            }
 
-            pub fn one(self) -> Result<T, postgres::Error> {
-                let stmt = self.stmt.prepare(self.client)?;
-                let row = self.client.query_one(stmt, &self.params)?;
-                Ok((self.mapper)((self.extractor)(&row)))
-            }
-
-            pub fn all(self) -> Result<Vec<T>, postgres::Error> {
-                self.iter()?.collect()
-            }
-
-            pub fn opt(self) -> Result<Option<T>, postgres::Error> {
-                let stmt = self.stmt.prepare(self.client)?;
-                Ok(self
-                    .client
-                    .query_opt(stmt, &self.params)?
-                    .map(|row| (self.mapper)((self.extractor)(&row))))
-            }
-
-            pub fn iter(
-                self,
-            ) -> Result<impl Iterator<Item = Result<T, postgres::Error>> + 'a, postgres::Error>
-            {
-                let stmt = self.stmt.prepare(self.client)?;
-                let it = self
-                    .client
-                    .query_raw(stmt, cornucopia_sync::private::slice_iter(&self.params))?
-                    .iterator()
-                    .map(move |res| res.map(|row| (self.mapper)((self.extractor)(&row))));
-                Ok(it)
-            }
-        }
         #[derive(serde::Serialize, Debug, Clone, PartialEq)]
         pub struct SelectNightmareDomainNull {
             pub txt: Option<String>,
@@ -1181,60 +1045,8 @@ pub mod queries {
                 }
             }
         }
-        pub struct SelectNightmareDomainNullQuery<'a, C: GenericClient, T, const N: usize> {
-            client: &'a mut C,
-            params: [&'a (dyn postgres_types::ToSql + Sync); N],
-            stmt: &'a mut cornucopia_sync::private::Stmt,
-            extractor: fn(&postgres::Row) -> SelectNightmareDomainNullBorrowed,
-            mapper: fn(SelectNightmareDomainNullBorrowed) -> T,
-        }
-        impl<'a, C, T: 'a, const N: usize> SelectNightmareDomainNullQuery<'a, C, T, N>
-        where
-            C: GenericClient,
-        {
-            pub fn map<R>(
-                self,
-                mapper: fn(SelectNightmareDomainNullBorrowed) -> R,
-            ) -> SelectNightmareDomainNullQuery<'a, C, R, N> {
-                SelectNightmareDomainNullQuery {
-                    client: self.client,
-                    params: self.params,
-                    stmt: self.stmt,
-                    extractor: self.extractor,
-                    mapper,
-                }
-            }
-
-            pub fn one(self) -> Result<T, postgres::Error> {
-                let stmt = self.stmt.prepare(self.client)?;
-                let row = self.client.query_one(stmt, &self.params)?;
-                Ok((self.mapper)((self.extractor)(&row)))
-            }
-
-            pub fn all(self) -> Result<Vec<T>, postgres::Error> {
-                self.iter()?.collect()
-            }
-
-            pub fn opt(self) -> Result<Option<T>, postgres::Error> {
-                let stmt = self.stmt.prepare(self.client)?;
-                Ok(self
-                    .client
-                    .query_opt(stmt, &self.params)?
-                    .map(|row| (self.mapper)((self.extractor)(&row))))
-            }
-
-            pub fn iter(
-                self,
-            ) -> Result<impl Iterator<Item = Result<T, postgres::Error>> + 'a, postgres::Error>
-            {
-                let stmt = self.stmt.prepare(self.client)?;
-                let it = self
-                    .client
-                    .query_raw(stmt, cornucopia_sync::private::slice_iter(&self.params))?
-                    .iterator()
-                    .map(move |res| res.map(|row| (self.mapper)((self.extractor)(&row))));
-                Ok(it)
-            }
+        impl cornucopia_sync::Borrow for SelectNightmareDomainNull {
+            type Borrow<'r> = SelectNightmareDomainNullBorrowed<'r>;
         }
         pub fn select_nightmare_domain() -> SelectNightmareDomainStmt {
             SelectNightmareDomainStmt(cornucopia_sync::private::Stmt::new(
@@ -1246,8 +1058,14 @@ pub mod queries {
             pub fn bind<'a, C: GenericClient>(
                 &'a mut self,
                 client: &'a mut C,
-            ) -> SelectNightmareDomainQuery<'a, C, SelectNightmareDomain, 0> {
-                SelectNightmareDomainQuery {
+            ) -> cornucopia_sync::private::Query<
+                'a,
+                C,
+                SelectNightmareDomain,
+                SelectNightmareDomain,
+                0,
+            > {
+                cornucopia_sync::private::Query {
                     client,
                     params: [],
                     stmt: &mut self.0,
@@ -1338,8 +1156,14 @@ pub mod queries {
             pub fn bind<'a, C: GenericClient>(
                 &'a mut self,
                 client: &'a mut C,
-            ) -> SelectNightmareDomainNullQuery<'a, C, SelectNightmareDomainNull, 0> {
-                SelectNightmareDomainNullQuery {
+            ) -> cornucopia_sync::private::Query<
+                'a,
+                C,
+                SelectNightmareDomainNull,
+                SelectNightmareDomainNull,
+                0,
+            > {
+                cornucopia_sync::private::Query {
                     client,
                     params: [],
                     stmt: &mut self.0,
@@ -1371,57 +1195,8 @@ pub mod queries {
         pub struct Id {
             pub id: i32,
         }
-        pub struct IdQuery<'a, C: GenericClient, T, const N: usize> {
-            client: &'a mut C,
-            params: [&'a (dyn postgres_types::ToSql + Sync); N],
-            stmt: &'a mut cornucopia_sync::private::Stmt,
-            extractor: fn(&postgres::Row) -> Id,
-            mapper: fn(Id) -> T,
-        }
-        impl<'a, C, T: 'a, const N: usize> IdQuery<'a, C, T, N>
-        where
-            C: GenericClient,
-        {
-            pub fn map<R>(self, mapper: fn(Id) -> R) -> IdQuery<'a, C, R, N> {
-                IdQuery {
-                    client: self.client,
-                    params: self.params,
-                    stmt: self.stmt,
-                    extractor: self.extractor,
-                    mapper,
-                }
-            }
-
-            pub fn one(self) -> Result<T, postgres::Error> {
-                let stmt = self.stmt.prepare(self.client)?;
-                let row = self.client.query_one(stmt, &self.params)?;
-                Ok((self.mapper)((self.extractor)(&row)))
-            }
-
-            pub fn all(self) -> Result<Vec<T>, postgres::Error> {
-                self.iter()?.collect()
-            }
-
-            pub fn opt(self) -> Result<Option<T>, postgres::Error> {
-                let stmt = self.stmt.prepare(self.client)?;
-                Ok(self
-                    .client
-                    .query_opt(stmt, &self.params)?
-                    .map(|row| (self.mapper)((self.extractor)(&row))))
-            }
-
-            pub fn iter(
-                self,
-            ) -> Result<impl Iterator<Item = Result<T, postgres::Error>> + 'a, postgres::Error>
-            {
-                let stmt = self.stmt.prepare(self.client)?;
-                let it = self
-                    .client
-                    .query_raw(stmt, cornucopia_sync::private::slice_iter(&self.params))?
-                    .iterator()
-                    .map(move |res| res.map(|row| (self.mapper)((self.extractor)(&row))));
-                Ok(it)
-            }
+        impl cornucopia_sync::Borrow for Id {
+            type Borrow<'r> = Id;
         }
         #[derive(serde::Serialize, Debug, Clone, PartialEq)]
         pub struct Named {
@@ -1453,114 +1228,10 @@ pub mod queries {
                 }
             }
         }
-        pub struct NamedQuery<'a, C: GenericClient, T, const N: usize> {
-            client: &'a mut C,
-            params: [&'a (dyn postgres_types::ToSql + Sync); N],
-            stmt: &'a mut cornucopia_sync::private::Stmt,
-            extractor: fn(&postgres::Row) -> NamedBorrowed,
-            mapper: fn(NamedBorrowed) -> T,
-        }
-        impl<'a, C, T: 'a, const N: usize> NamedQuery<'a, C, T, N>
-        where
-            C: GenericClient,
-        {
-            pub fn map<R>(self, mapper: fn(NamedBorrowed) -> R) -> NamedQuery<'a, C, R, N> {
-                NamedQuery {
-                    client: self.client,
-                    params: self.params,
-                    stmt: self.stmt,
-                    extractor: self.extractor,
-                    mapper,
-                }
-            }
-
-            pub fn one(self) -> Result<T, postgres::Error> {
-                let stmt = self.stmt.prepare(self.client)?;
-                let row = self.client.query_one(stmt, &self.params)?;
-                Ok((self.mapper)((self.extractor)(&row)))
-            }
-
-            pub fn all(self) -> Result<Vec<T>, postgres::Error> {
-                self.iter()?.collect()
-            }
-
-            pub fn opt(self) -> Result<Option<T>, postgres::Error> {
-                let stmt = self.stmt.prepare(self.client)?;
-                Ok(self
-                    .client
-                    .query_opt(stmt, &self.params)?
-                    .map(|row| (self.mapper)((self.extractor)(&row))))
-            }
-
-            pub fn iter(
-                self,
-            ) -> Result<impl Iterator<Item = Result<T, postgres::Error>> + 'a, postgres::Error>
-            {
-                let stmt = self.stmt.prepare(self.client)?;
-                let it = self
-                    .client
-                    .query_raw(stmt, cornucopia_sync::private::slice_iter(&self.params))?
-                    .iterator()
-                    .map(move |res| res.map(|row| (self.mapper)((self.extractor)(&row))));
-                Ok(it)
-            }
+        impl cornucopia_sync::Borrow for Named {
+            type Borrow<'r> = NamedBorrowed<'r>;
         }
 
-        pub struct SuperSuperTypesPublicNamedCompositeQuery<'a, C: GenericClient, T, const N: usize> {
-            client: &'a mut C,
-            params: [&'a (dyn postgres_types::ToSql + Sync); N],
-            stmt: &'a mut cornucopia_sync::private::Stmt,
-            extractor: fn(&postgres::Row) -> super::super::types::public::NamedCompositeBorrowed,
-            mapper: fn(super::super::types::public::NamedCompositeBorrowed) -> T,
-        }
-        impl<'a, C, T: 'a, const N: usize> SuperSuperTypesPublicNamedCompositeQuery<'a, C, T, N>
-        where
-            C: GenericClient,
-        {
-            pub fn map<R>(
-                self,
-                mapper: fn(super::super::types::public::NamedCompositeBorrowed) -> R,
-            ) -> SuperSuperTypesPublicNamedCompositeQuery<'a, C, R, N> {
-                SuperSuperTypesPublicNamedCompositeQuery {
-                    client: self.client,
-                    params: self.params,
-                    stmt: self.stmt,
-                    extractor: self.extractor,
-                    mapper,
-                }
-            }
-
-            pub fn one(self) -> Result<T, postgres::Error> {
-                let stmt = self.stmt.prepare(self.client)?;
-                let row = self.client.query_one(stmt, &self.params)?;
-                Ok((self.mapper)((self.extractor)(&row)))
-            }
-
-            pub fn all(self) -> Result<Vec<T>, postgres::Error> {
-                self.iter()?.collect()
-            }
-
-            pub fn opt(self) -> Result<Option<T>, postgres::Error> {
-                let stmt = self.stmt.prepare(self.client)?;
-                Ok(self
-                    .client
-                    .query_opt(stmt, &self.params)?
-                    .map(|row| (self.mapper)((self.extractor)(&row))))
-            }
-
-            pub fn iter(
-                self,
-            ) -> Result<impl Iterator<Item = Result<T, postgres::Error>> + 'a, postgres::Error>
-            {
-                let stmt = self.stmt.prepare(self.client)?;
-                let it = self
-                    .client
-                    .query_raw(stmt, cornucopia_sync::private::slice_iter(&self.params))?
-                    .iterator()
-                    .map(move |res| res.map(|row| (self.mapper)((self.extractor)(&row))));
-                Ok(it)
-            }
-        }
         pub fn new_named_visible() -> NewNamedVisibleStmt {
             NewNamedVisibleStmt(cornucopia_sync::private::Stmt::new(
                 "INSERT INTO named (name, price, show) VALUES ($1, $2, true) RETURNING id ",
@@ -1573,8 +1244,8 @@ pub mod queries {
                 client: &'a mut C,
                 name: &'a T1,
                 price: &'a Option<f64>,
-            ) -> IdQuery<'a, C, Id, 2> {
-                IdQuery {
+            ) -> cornucopia_sync::private::Query<'a, C, Id, Id, 2> {
+                cornucopia_sync::private::Query {
                     client,
                     params: [name, price],
                     stmt: &mut self.0,
@@ -1584,14 +1255,18 @@ pub mod queries {
             }
         }
         impl<'a, C: GenericClient, T1: cornucopia_sync::StringSql>
-            cornucopia_sync::Params<'a, NamedParams<T1>, IdQuery<'a, C, Id, 2>, C>
-            for NewNamedVisibleStmt
+            cornucopia_sync::Params<
+                'a,
+                NamedParams<T1>,
+                cornucopia_sync::private::Query<'a, C, Id, Id, 2>,
+                C,
+            > for NewNamedVisibleStmt
         {
             fn params(
                 &'a mut self,
                 client: &'a mut C,
                 params: &'a NamedParams<T1>,
-            ) -> IdQuery<'a, C, Id, 2> {
+            ) -> cornucopia_sync::private::Query<'a, C, Id, Id, 2> {
                 self.bind(client, &params.name, &params.price)
             }
         }
@@ -1607,8 +1282,8 @@ pub mod queries {
                 client: &'a mut C,
                 price: &'a Option<f64>,
                 name: &'a T1,
-            ) -> IdQuery<'a, C, Id, 2> {
-                IdQuery {
+            ) -> cornucopia_sync::private::Query<'a, C, Id, Id, 2> {
+                cornucopia_sync::private::Query {
                     client,
                     params: [price, name],
                     stmt: &mut self.0,
@@ -1618,14 +1293,18 @@ pub mod queries {
             }
         }
         impl<'a, C: GenericClient, T1: cornucopia_sync::StringSql>
-            cornucopia_sync::Params<'a, NamedParams<T1>, IdQuery<'a, C, Id, 2>, C>
-            for NewNamedHiddenStmt
+            cornucopia_sync::Params<
+                'a,
+                NamedParams<T1>,
+                cornucopia_sync::private::Query<'a, C, Id, Id, 2>,
+                C,
+            > for NewNamedHiddenStmt
         {
             fn params(
                 &'a mut self,
                 client: &'a mut C,
                 params: &'a NamedParams<T1>,
-            ) -> IdQuery<'a, C, Id, 2> {
+            ) -> cornucopia_sync::private::Query<'a, C, Id, Id, 2> {
                 self.bind(client, &params.price, &params.name)
             }
         }
@@ -1637,8 +1316,8 @@ pub mod queries {
             pub fn bind<'a, C: GenericClient>(
                 &'a mut self,
                 client: &'a mut C,
-            ) -> NamedQuery<'a, C, Named, 0> {
-                NamedQuery {
+            ) -> cornucopia_sync::private::Query<'a, C, Named, Named, 0> {
+                cornucopia_sync::private::Query {
                     client,
                     params: [],
                     stmt: &mut self.0,
@@ -1663,8 +1342,8 @@ pub mod queries {
                 &'a mut self,
                 client: &'a mut C,
                 id: &'a i32,
-            ) -> NamedQuery<'a, C, Named, 1> {
-                NamedQuery {
+            ) -> cornucopia_sync::private::Query<'a, C, Named, Named, 1> {
+                cornucopia_sync::private::Query {
                     client,
                     params: [id],
                     stmt: &mut self.0,
@@ -1717,13 +1396,14 @@ pub mod queries {
             pub fn bind<'a, C: GenericClient>(
                 &'a mut self,
                 client: &'a mut C,
-            ) -> SuperSuperTypesPublicNamedCompositeQuery<
+            ) -> cornucopia_sync::private::Query<
                 'a,
                 C,
                 super::super::types::public::NamedComposite,
+                super::super::types::public::NamedComposite,
                 0,
             > {
-                SuperSuperTypesPublicNamedCompositeQuery {
+                cornucopia_sync::private::Query {
                     client,
                     params: [],
                     stmt: &mut self.0,
@@ -1772,57 +1452,8 @@ pub mod queries {
                 }
             }
         }
-        pub struct NullityQuery<'a, C: GenericClient, T, const N: usize> {
-            client: &'a mut C,
-            params: [&'a (dyn postgres_types::ToSql + Sync); N],
-            stmt: &'a mut cornucopia_sync::private::Stmt,
-            extractor: fn(&postgres::Row) -> NullityBorrowed,
-            mapper: fn(NullityBorrowed) -> T,
-        }
-        impl<'a, C, T: 'a, const N: usize> NullityQuery<'a, C, T, N>
-        where
-            C: GenericClient,
-        {
-            pub fn map<R>(self, mapper: fn(NullityBorrowed) -> R) -> NullityQuery<'a, C, R, N> {
-                NullityQuery {
-                    client: self.client,
-                    params: self.params,
-                    stmt: self.stmt,
-                    extractor: self.extractor,
-                    mapper,
-                }
-            }
-
-            pub fn one(self) -> Result<T, postgres::Error> {
-                let stmt = self.stmt.prepare(self.client)?;
-                let row = self.client.query_one(stmt, &self.params)?;
-                Ok((self.mapper)((self.extractor)(&row)))
-            }
-
-            pub fn all(self) -> Result<Vec<T>, postgres::Error> {
-                self.iter()?.collect()
-            }
-
-            pub fn opt(self) -> Result<Option<T>, postgres::Error> {
-                let stmt = self.stmt.prepare(self.client)?;
-                Ok(self
-                    .client
-                    .query_opt(stmt, &self.params)?
-                    .map(|row| (self.mapper)((self.extractor)(&row))))
-            }
-
-            pub fn iter(
-                self,
-            ) -> Result<impl Iterator<Item = Result<T, postgres::Error>> + 'a, postgres::Error>
-            {
-                let stmt = self.stmt.prepare(self.client)?;
-                let it = self
-                    .client
-                    .query_raw(stmt, cornucopia_sync::private::slice_iter(&self.params))?
-                    .iterator()
-                    .map(move |res| res.map(|row| (self.mapper)((self.extractor)(&row))));
-                Ok(it)
-            }
+        impl cornucopia_sync::Borrow for Nullity {
+            type Borrow<'r> = NullityBorrowed<'r>;
         }
         pub fn new_nullity() -> NewNullityStmt {
             NewNullityStmt(cornucopia_sync::private::Stmt::new(
@@ -1879,8 +1510,8 @@ pub mod queries {
             pub fn bind<'a, C: GenericClient>(
                 &'a mut self,
                 client: &'a mut C,
-            ) -> NullityQuery<'a, C, Nullity, 0> {
-                NullityQuery {
+            ) -> cornucopia_sync::private::Query<'a, C, Nullity, Nullity, 0> {
+                cornucopia_sync::private::Query {
                     client,
                     params: [],
                     stmt: &mut self.0,
@@ -1924,61 +1555,10 @@ pub mod queries {
                 }
             }
         }
-        pub struct SelectBookQuery<'a, C: GenericClient, T, const N: usize> {
-            client: &'a mut C,
-            params: [&'a (dyn postgres_types::ToSql + Sync); N],
-            stmt: &'a mut cornucopia_sync::private::Stmt,
-            extractor: fn(&postgres::Row) -> SelectBookBorrowed,
-            mapper: fn(SelectBookBorrowed) -> T,
+        impl cornucopia_sync::Borrow for SelectBook {
+            type Borrow<'r> = SelectBookBorrowed<'r>;
         }
-        impl<'a, C, T: 'a, const N: usize> SelectBookQuery<'a, C, T, N>
-        where
-            C: GenericClient,
-        {
-            pub fn map<R>(
-                self,
-                mapper: fn(SelectBookBorrowed) -> R,
-            ) -> SelectBookQuery<'a, C, R, N> {
-                SelectBookQuery {
-                    client: self.client,
-                    params: self.params,
-                    stmt: self.stmt,
-                    extractor: self.extractor,
-                    mapper,
-                }
-            }
 
-            pub fn one(self) -> Result<T, postgres::Error> {
-                let stmt = self.stmt.prepare(self.client)?;
-                let row = self.client.query_one(stmt, &self.params)?;
-                Ok((self.mapper)((self.extractor)(&row)))
-            }
-
-            pub fn all(self) -> Result<Vec<T>, postgres::Error> {
-                self.iter()?.collect()
-            }
-
-            pub fn opt(self) -> Result<Option<T>, postgres::Error> {
-                let stmt = self.stmt.prepare(self.client)?;
-                Ok(self
-                    .client
-                    .query_opt(stmt, &self.params)?
-                    .map(|row| (self.mapper)((self.extractor)(&row))))
-            }
-
-            pub fn iter(
-                self,
-            ) -> Result<impl Iterator<Item = Result<T, postgres::Error>> + 'a, postgres::Error>
-            {
-                let stmt = self.stmt.prepare(self.client)?;
-                let it = self
-                    .client
-                    .query_raw(stmt, cornucopia_sync::private::slice_iter(&self.params))?
-                    .iterator()
-                    .map(move |res| res.map(|row| (self.mapper)((self.extractor)(&row))));
-                Ok(it)
-            }
-        }
         #[derive(serde::Serialize, Debug, Clone, PartialEq)]
         pub struct FindBooks {
             pub name: String,
@@ -1996,57 +1576,8 @@ pub mod queries {
                 }
             }
         }
-        pub struct FindBooksQuery<'a, C: GenericClient, T, const N: usize> {
-            client: &'a mut C,
-            params: [&'a (dyn postgres_types::ToSql + Sync); N],
-            stmt: &'a mut cornucopia_sync::private::Stmt,
-            extractor: fn(&postgres::Row) -> FindBooksBorrowed,
-            mapper: fn(FindBooksBorrowed) -> T,
-        }
-        impl<'a, C, T: 'a, const N: usize> FindBooksQuery<'a, C, T, N>
-        where
-            C: GenericClient,
-        {
-            pub fn map<R>(self, mapper: fn(FindBooksBorrowed) -> R) -> FindBooksQuery<'a, C, R, N> {
-                FindBooksQuery {
-                    client: self.client,
-                    params: self.params,
-                    stmt: self.stmt,
-                    extractor: self.extractor,
-                    mapper,
-                }
-            }
-
-            pub fn one(self) -> Result<T, postgres::Error> {
-                let stmt = self.stmt.prepare(self.client)?;
-                let row = self.client.query_one(stmt, &self.params)?;
-                Ok((self.mapper)((self.extractor)(&row)))
-            }
-
-            pub fn all(self) -> Result<Vec<T>, postgres::Error> {
-                self.iter()?.collect()
-            }
-
-            pub fn opt(self) -> Result<Option<T>, postgres::Error> {
-                let stmt = self.stmt.prepare(self.client)?;
-                Ok(self
-                    .client
-                    .query_opt(stmt, &self.params)?
-                    .map(|row| (self.mapper)((self.extractor)(&row))))
-            }
-
-            pub fn iter(
-                self,
-            ) -> Result<impl Iterator<Item = Result<T, postgres::Error>> + 'a, postgres::Error>
-            {
-                let stmt = self.stmt.prepare(self.client)?;
-                let it = self
-                    .client
-                    .query_raw(stmt, cornucopia_sync::private::slice_iter(&self.params))?
-                    .iterator()
-                    .map(move |res| res.map(|row| (self.mapper)((self.extractor)(&row))));
-                Ok(it)
-            }
+        impl cornucopia_sync::Borrow for FindBooks {
+            type Borrow<'r> = FindBooksBorrowed<'r>;
         }
         pub fn insert_book() -> InsertBookStmt {
             InsertBookStmt(cornucopia_sync::private::Stmt::new(
@@ -2096,8 +1627,8 @@ pub mod queries {
             pub fn bind<'a, C: GenericClient>(
                 &'a mut self,
                 client: &'a mut C,
-            ) -> SelectBookQuery<'a, C, SelectBook, 0> {
-                SelectBookQuery {
+            ) -> cornucopia_sync::private::Query<'a, C, SelectBook, SelectBook, 0> {
+                cornucopia_sync::private::Query {
                     client,
                     params: [],
                     stmt: &mut self.0,
@@ -2125,8 +1656,8 @@ pub mod queries {
                 &'a mut self,
                 client: &'a mut C,
                 title: &'a T2,
-            ) -> FindBooksQuery<'a, C, FindBooks, 1> {
-                FindBooksQuery {
+            ) -> cornucopia_sync::private::Query<'a, C, FindBooks, FindBooks, 1> {
+                cornucopia_sync::private::Query {
                     client,
                     params: [title],
                     stmt: &mut self.0,
@@ -2437,61 +1968,10 @@ pub mod queries {
                 }
             }
         }
-        pub struct EverythingQuery<'a, C: GenericClient, T, const N: usize> {
-            client: &'a mut C,
-            params: [&'a (dyn postgres_types::ToSql + Sync); N],
-            stmt: &'a mut cornucopia_sync::private::Stmt,
-            extractor: fn(&postgres::Row) -> EverythingBorrowed,
-            mapper: fn(EverythingBorrowed) -> T,
+        impl cornucopia_sync::Borrow for Everything {
+            type Borrow<'r> = EverythingBorrowed<'r>;
         }
-        impl<'a, C, T: 'a, const N: usize> EverythingQuery<'a, C, T, N>
-        where
-            C: GenericClient,
-        {
-            pub fn map<R>(
-                self,
-                mapper: fn(EverythingBorrowed) -> R,
-            ) -> EverythingQuery<'a, C, R, N> {
-                EverythingQuery {
-                    client: self.client,
-                    params: self.params,
-                    stmt: self.stmt,
-                    extractor: self.extractor,
-                    mapper,
-                }
-            }
 
-            pub fn one(self) -> Result<T, postgres::Error> {
-                let stmt = self.stmt.prepare(self.client)?;
-                let row = self.client.query_one(stmt, &self.params)?;
-                Ok((self.mapper)((self.extractor)(&row)))
-            }
-
-            pub fn all(self) -> Result<Vec<T>, postgres::Error> {
-                self.iter()?.collect()
-            }
-
-            pub fn opt(self) -> Result<Option<T>, postgres::Error> {
-                let stmt = self.stmt.prepare(self.client)?;
-                Ok(self
-                    .client
-                    .query_opt(stmt, &self.params)?
-                    .map(|row| (self.mapper)((self.extractor)(&row))))
-            }
-
-            pub fn iter(
-                self,
-            ) -> Result<impl Iterator<Item = Result<T, postgres::Error>> + 'a, postgres::Error>
-            {
-                let stmt = self.stmt.prepare(self.client)?;
-                let it = self
-                    .client
-                    .query_raw(stmt, cornucopia_sync::private::slice_iter(&self.params))?
-                    .iterator()
-                    .map(move |res| res.map(|row| (self.mapper)((self.extractor)(&row))));
-                Ok(it)
-            }
-        }
         #[derive(serde::Serialize, Debug, Clone, PartialEq)]
         pub struct EverythingNull {
             pub bool_: Option<bool>,
@@ -2638,61 +2118,10 @@ pub mod queries {
                 }
             }
         }
-        pub struct EverythingNullQuery<'a, C: GenericClient, T, const N: usize> {
-            client: &'a mut C,
-            params: [&'a (dyn postgres_types::ToSql + Sync); N],
-            stmt: &'a mut cornucopia_sync::private::Stmt,
-            extractor: fn(&postgres::Row) -> EverythingNullBorrowed,
-            mapper: fn(EverythingNullBorrowed) -> T,
+        impl cornucopia_sync::Borrow for EverythingNull {
+            type Borrow<'r> = EverythingNullBorrowed<'r>;
         }
-        impl<'a, C, T: 'a, const N: usize> EverythingNullQuery<'a, C, T, N>
-        where
-            C: GenericClient,
-        {
-            pub fn map<R>(
-                self,
-                mapper: fn(EverythingNullBorrowed) -> R,
-            ) -> EverythingNullQuery<'a, C, R, N> {
-                EverythingNullQuery {
-                    client: self.client,
-                    params: self.params,
-                    stmt: self.stmt,
-                    extractor: self.extractor,
-                    mapper,
-                }
-            }
 
-            pub fn one(self) -> Result<T, postgres::Error> {
-                let stmt = self.stmt.prepare(self.client)?;
-                let row = self.client.query_one(stmt, &self.params)?;
-                Ok((self.mapper)((self.extractor)(&row)))
-            }
-
-            pub fn all(self) -> Result<Vec<T>, postgres::Error> {
-                self.iter()?.collect()
-            }
-
-            pub fn opt(self) -> Result<Option<T>, postgres::Error> {
-                let stmt = self.stmt.prepare(self.client)?;
-                Ok(self
-                    .client
-                    .query_opt(stmt, &self.params)?
-                    .map(|row| (self.mapper)((self.extractor)(&row))))
-            }
-
-            pub fn iter(
-                self,
-            ) -> Result<impl Iterator<Item = Result<T, postgres::Error>> + 'a, postgres::Error>
-            {
-                let stmt = self.stmt.prepare(self.client)?;
-                let it = self
-                    .client
-                    .query_raw(stmt, cornucopia_sync::private::slice_iter(&self.params))?
-                    .iterator()
-                    .map(move |res| res.map(|row| (self.mapper)((self.extractor)(&row))));
-                Ok(it)
-            }
-        }
         #[derive(serde::Serialize, Debug, Clone, PartialEq)]
         pub struct EverythingArray {
             pub bool_: Vec<bool>,
@@ -2826,61 +2255,10 @@ pub mod queries {
                 }
             }
         }
-        pub struct EverythingArrayQuery<'a, C: GenericClient, T, const N: usize> {
-            client: &'a mut C,
-            params: [&'a (dyn postgres_types::ToSql + Sync); N],
-            stmt: &'a mut cornucopia_sync::private::Stmt,
-            extractor: fn(&postgres::Row) -> EverythingArrayBorrowed,
-            mapper: fn(EverythingArrayBorrowed) -> T,
+        impl cornucopia_sync::Borrow for EverythingArray {
+            type Borrow<'r> = EverythingArrayBorrowed<'r>;
         }
-        impl<'a, C, T: 'a, const N: usize> EverythingArrayQuery<'a, C, T, N>
-        where
-            C: GenericClient,
-        {
-            pub fn map<R>(
-                self,
-                mapper: fn(EverythingArrayBorrowed) -> R,
-            ) -> EverythingArrayQuery<'a, C, R, N> {
-                EverythingArrayQuery {
-                    client: self.client,
-                    params: self.params,
-                    stmt: self.stmt,
-                    extractor: self.extractor,
-                    mapper,
-                }
-            }
 
-            pub fn one(self) -> Result<T, postgres::Error> {
-                let stmt = self.stmt.prepare(self.client)?;
-                let row = self.client.query_one(stmt, &self.params)?;
-                Ok((self.mapper)((self.extractor)(&row)))
-            }
-
-            pub fn all(self) -> Result<Vec<T>, postgres::Error> {
-                self.iter()?.collect()
-            }
-
-            pub fn opt(self) -> Result<Option<T>, postgres::Error> {
-                let stmt = self.stmt.prepare(self.client)?;
-                Ok(self
-                    .client
-                    .query_opt(stmt, &self.params)?
-                    .map(|row| (self.mapper)((self.extractor)(&row))))
-            }
-
-            pub fn iter(
-                self,
-            ) -> Result<impl Iterator<Item = Result<T, postgres::Error>> + 'a, postgres::Error>
-            {
-                let stmt = self.stmt.prepare(self.client)?;
-                let it = self
-                    .client
-                    .query_raw(stmt, cornucopia_sync::private::slice_iter(&self.params))?
-                    .iterator()
-                    .map(move |res| res.map(|row| (self.mapper)((self.extractor)(&row))));
-                Ok(it)
-            }
-        }
         #[derive(serde::Serialize, Debug, Clone, PartialEq)]
         pub struct EverythingArrayNull {
             pub bool_: Option<Vec<bool>>,
@@ -3023,123 +2401,10 @@ pub mod queries {
                 }
             }
         }
-        pub struct EverythingArrayNullQuery<'a, C: GenericClient, T, const N: usize> {
-            client: &'a mut C,
-            params: [&'a (dyn postgres_types::ToSql + Sync); N],
-            stmt: &'a mut cornucopia_sync::private::Stmt,
-            extractor: fn(&postgres::Row) -> EverythingArrayNullBorrowed,
-            mapper: fn(EverythingArrayNullBorrowed) -> T,
-        }
-        impl<'a, C, T: 'a, const N: usize> EverythingArrayNullQuery<'a, C, T, N>
-        where
-            C: GenericClient,
-        {
-            pub fn map<R>(
-                self,
-                mapper: fn(EverythingArrayNullBorrowed) -> R,
-            ) -> EverythingArrayNullQuery<'a, C, R, N> {
-                EverythingArrayNullQuery {
-                    client: self.client,
-                    params: self.params,
-                    stmt: self.stmt,
-                    extractor: self.extractor,
-                    mapper,
-                }
-            }
-
-            pub fn one(self) -> Result<T, postgres::Error> {
-                let stmt = self.stmt.prepare(self.client)?;
-                let row = self.client.query_one(stmt, &self.params)?;
-                Ok((self.mapper)((self.extractor)(&row)))
-            }
-
-            pub fn all(self) -> Result<Vec<T>, postgres::Error> {
-                self.iter()?.collect()
-            }
-
-            pub fn opt(self) -> Result<Option<T>, postgres::Error> {
-                let stmt = self.stmt.prepare(self.client)?;
-                Ok(self
-                    .client
-                    .query_opt(stmt, &self.params)?
-                    .map(|row| (self.mapper)((self.extractor)(&row))))
-            }
-
-            pub fn iter(
-                self,
-            ) -> Result<impl Iterator<Item = Result<T, postgres::Error>> + 'a, postgres::Error>
-            {
-                let stmt = self.stmt.prepare(self.client)?;
-                let it = self
-                    .client
-                    .query_raw(stmt, cornucopia_sync::private::slice_iter(&self.params))?
-                    .iterator()
-                    .map(move |res| res.map(|row| (self.mapper)((self.extractor)(&row))));
-                Ok(it)
-            }
+        impl cornucopia_sync::Borrow for EverythingArrayNull {
+            type Borrow<'r> = EverythingArrayNullBorrowed<'r>;
         }
 
-        pub struct SuperSuperTypesPublicNightmareCompositeQuery<
-            'a,
-            C: GenericClient,
-            T,
-            const N: usize,
-        > {
-            client: &'a mut C,
-            params: [&'a (dyn postgres_types::ToSql + Sync); N],
-            stmt: &'a mut cornucopia_sync::private::Stmt,
-            extractor:
-                fn(&postgres::Row) -> super::super::types::public::NightmareCompositeBorrowed,
-            mapper: fn(super::super::types::public::NightmareCompositeBorrowed) -> T,
-        }
-        impl<'a, C, T: 'a, const N: usize> SuperSuperTypesPublicNightmareCompositeQuery<'a, C, T, N>
-        where
-            C: GenericClient,
-        {
-            pub fn map<R>(
-                self,
-                mapper: fn(super::super::types::public::NightmareCompositeBorrowed) -> R,
-            ) -> SuperSuperTypesPublicNightmareCompositeQuery<'a, C, R, N> {
-                SuperSuperTypesPublicNightmareCompositeQuery {
-                    client: self.client,
-                    params: self.params,
-                    stmt: self.stmt,
-                    extractor: self.extractor,
-                    mapper,
-                }
-            }
-
-            pub fn one(self) -> Result<T, postgres::Error> {
-                let stmt = self.stmt.prepare(self.client)?;
-                let row = self.client.query_one(stmt, &self.params)?;
-                Ok((self.mapper)((self.extractor)(&row)))
-            }
-
-            pub fn all(self) -> Result<Vec<T>, postgres::Error> {
-                self.iter()?.collect()
-            }
-
-            pub fn opt(self) -> Result<Option<T>, postgres::Error> {
-                let stmt = self.stmt.prepare(self.client)?;
-                Ok(self
-                    .client
-                    .query_opt(stmt, &self.params)?
-                    .map(|row| (self.mapper)((self.extractor)(&row))))
-            }
-
-            pub fn iter(
-                self,
-            ) -> Result<impl Iterator<Item = Result<T, postgres::Error>> + 'a, postgres::Error>
-            {
-                let stmt = self.stmt.prepare(self.client)?;
-                let it = self
-                    .client
-                    .query_raw(stmt, cornucopia_sync::private::slice_iter(&self.params))?
-                    .iterator()
-                    .map(move |res| res.map(|row| (self.mapper)((self.extractor)(&row))));
-                Ok(it)
-            }
-        }
         pub fn select_everything() -> SelectEverythingStmt {
             SelectEverythingStmt(cornucopia_sync::private::Stmt::new(
                 "SELECT * FROM Everything",
@@ -3150,8 +2415,8 @@ pub mod queries {
             pub fn bind<'a, C: GenericClient>(
                 &'a mut self,
                 client: &'a mut C,
-            ) -> EverythingQuery<'a, C, Everything, 0> {
-                EverythingQuery {
+            ) -> cornucopia_sync::private::Query<'a, C, Everything, Everything, 0> {
+                cornucopia_sync::private::Query {
                     client,
                     params: [],
                     stmt: &mut self.0,
@@ -3204,8 +2469,9 @@ pub mod queries {
             pub fn bind<'a, C: GenericClient>(
                 &'a mut self,
                 client: &'a mut C,
-            ) -> EverythingNullQuery<'a, C, EverythingNull, 0> {
-                EverythingNullQuery {
+            ) -> cornucopia_sync::private::Query<'a, C, EverythingNull, EverythingNull, 0>
+            {
+                cornucopia_sync::private::Query {
                     client,
                     params: [],
                     stmt: &mut self.0,
@@ -3410,8 +2676,9 @@ pub mod queries {
             pub fn bind<'a, C: GenericClient>(
                 &'a mut self,
                 client: &'a mut C,
-            ) -> EverythingArrayQuery<'a, C, EverythingArray, 0> {
-                EverythingArrayQuery {
+            ) -> cornucopia_sync::private::Query<'a, C, EverythingArray, EverythingArray, 0>
+            {
+                cornucopia_sync::private::Query {
                     client,
                     params: [],
                     stmt: &mut self.0,
@@ -3458,8 +2725,9 @@ pub mod queries {
             pub fn bind<'a, C: GenericClient>(
                 &'a mut self,
                 client: &'a mut C,
-            ) -> EverythingArrayNullQuery<'a, C, EverythingArrayNull, 0> {
-                EverythingArrayNullQuery {
+            ) -> cornucopia_sync::private::Query<'a, C, EverythingArrayNull, EverythingArrayNull, 0>
+            {
+                cornucopia_sync::private::Query {
                     client,
                     params: [],
                     stmt: &mut self.0,
@@ -3760,13 +3028,14 @@ pub mod queries {
             pub fn bind<'a, C: GenericClient>(
                 &'a mut self,
                 client: &'a mut C,
-            ) -> SuperSuperTypesPublicNightmareCompositeQuery<
+            ) -> cornucopia_sync::private::Query<
                 'a,
                 C,
                 super::super::types::public::NightmareComposite,
+                super::super::types::public::NightmareComposite,
                 0,
             > {
-                SuperSuperTypesPublicNightmareCompositeQuery {
+                cornucopia_sync::private::Query {
                     client,
                     params: [],
                     stmt: &mut self.0,
@@ -3815,225 +3084,19 @@ pub mod queries {
             pub price: f64,
         }
 
-        pub struct SuperSuperTypesPublicCloneCompositeQuery<'a, C: GenericClient, T, const N: usize> {
-            client: &'a mut C,
-            params: [&'a (dyn postgres_types::ToSql + Sync); N],
-            stmt: &'a mut cornucopia_sync::private::Stmt,
-            extractor: fn(&postgres::Row) -> super::super::types::public::CloneCompositeBorrowed,
-            mapper: fn(super::super::types::public::CloneCompositeBorrowed) -> T,
-        }
-        impl<'a, C, T: 'a, const N: usize> SuperSuperTypesPublicCloneCompositeQuery<'a, C, T, N>
-        where
-            C: GenericClient,
-        {
-            pub fn map<R>(
-                self,
-                mapper: fn(super::super::types::public::CloneCompositeBorrowed) -> R,
-            ) -> SuperSuperTypesPublicCloneCompositeQuery<'a, C, R, N> {
-                SuperSuperTypesPublicCloneCompositeQuery {
-                    client: self.client,
-                    params: self.params,
-                    stmt: self.stmt,
-                    extractor: self.extractor,
-                    mapper,
-                }
-            }
-
-            pub fn one(self) -> Result<T, postgres::Error> {
-                let stmt = self.stmt.prepare(self.client)?;
-                let row = self.client.query_one(stmt, &self.params)?;
-                Ok((self.mapper)((self.extractor)(&row)))
-            }
-
-            pub fn all(self) -> Result<Vec<T>, postgres::Error> {
-                self.iter()?.collect()
-            }
-
-            pub fn opt(self) -> Result<Option<T>, postgres::Error> {
-                let stmt = self.stmt.prepare(self.client)?;
-                Ok(self
-                    .client
-                    .query_opt(stmt, &self.params)?
-                    .map(|row| (self.mapper)((self.extractor)(&row))))
-            }
-
-            pub fn iter(
-                self,
-            ) -> Result<impl Iterator<Item = Result<T, postgres::Error>> + 'a, postgres::Error>
-            {
-                let stmt = self.stmt.prepare(self.client)?;
-                let it = self
-                    .client
-                    .query_raw(stmt, cornucopia_sync::private::slice_iter(&self.params))?
-                    .iterator()
-                    .map(move |res| res.map(|row| (self.mapper)((self.extractor)(&row))));
-                Ok(it)
-            }
-        }
-
-        pub struct Optioni32Query<'a, C: GenericClient, T, const N: usize> {
-            client: &'a mut C,
-            params: [&'a (dyn postgres_types::ToSql + Sync); N],
-            stmt: &'a mut cornucopia_sync::private::Stmt,
-            extractor: fn(&postgres::Row) -> Option<i32>,
-            mapper: fn(Option<i32>) -> T,
-        }
-        impl<'a, C, T: 'a, const N: usize> Optioni32Query<'a, C, T, N>
-        where
-            C: GenericClient,
-        {
-            pub fn map<R>(self, mapper: fn(Option<i32>) -> R) -> Optioni32Query<'a, C, R, N> {
-                Optioni32Query {
-                    client: self.client,
-                    params: self.params,
-                    stmt: self.stmt,
-                    extractor: self.extractor,
-                    mapper,
-                }
-            }
-
-            pub fn one(self) -> Result<T, postgres::Error> {
-                let stmt = self.stmt.prepare(self.client)?;
-                let row = self.client.query_one(stmt, &self.params)?;
-                Ok((self.mapper)((self.extractor)(&row)))
-            }
-
-            pub fn all(self) -> Result<Vec<T>, postgres::Error> {
-                self.iter()?.collect()
-            }
-
-            pub fn opt(self) -> Result<Option<T>, postgres::Error> {
-                let stmt = self.stmt.prepare(self.client)?;
-                Ok(self
-                    .client
-                    .query_opt(stmt, &self.params)?
-                    .map(|row| (self.mapper)((self.extractor)(&row))))
-            }
-
-            pub fn iter(
-                self,
-            ) -> Result<impl Iterator<Item = Result<T, postgres::Error>> + 'a, postgres::Error>
-            {
-                let stmt = self.stmt.prepare(self.client)?;
-                let it = self
-                    .client
-                    .query_raw(stmt, cornucopia_sync::private::slice_iter(&self.params))?
-                    .iterator()
-                    .map(move |res| res.map(|row| (self.mapper)((self.extractor)(&row))));
-                Ok(it)
-            }
-        }
         #[derive(serde::Serialize, Debug, Clone, PartialEq, Copy)]
         pub struct Row {
             pub id: i32,
         }
-        pub struct RowQuery<'a, C: GenericClient, T, const N: usize> {
-            client: &'a mut C,
-            params: [&'a (dyn postgres_types::ToSql + Sync); N],
-            stmt: &'a mut cornucopia_sync::private::Stmt,
-            extractor: fn(&postgres::Row) -> Row,
-            mapper: fn(Row) -> T,
-        }
-        impl<'a, C, T: 'a, const N: usize> RowQuery<'a, C, T, N>
-        where
-            C: GenericClient,
-        {
-            pub fn map<R>(self, mapper: fn(Row) -> R) -> RowQuery<'a, C, R, N> {
-                RowQuery {
-                    client: self.client,
-                    params: self.params,
-                    stmt: self.stmt,
-                    extractor: self.extractor,
-                    mapper,
-                }
-            }
-
-            pub fn one(self) -> Result<T, postgres::Error> {
-                let stmt = self.stmt.prepare(self.client)?;
-                let row = self.client.query_one(stmt, &self.params)?;
-                Ok((self.mapper)((self.extractor)(&row)))
-            }
-
-            pub fn all(self) -> Result<Vec<T>, postgres::Error> {
-                self.iter()?.collect()
-            }
-
-            pub fn opt(self) -> Result<Option<T>, postgres::Error> {
-                let stmt = self.stmt.prepare(self.client)?;
-                Ok(self
-                    .client
-                    .query_opt(stmt, &self.params)?
-                    .map(|row| (self.mapper)((self.extractor)(&row))))
-            }
-
-            pub fn iter(
-                self,
-            ) -> Result<impl Iterator<Item = Result<T, postgres::Error>> + 'a, postgres::Error>
-            {
-                let stmt = self.stmt.prepare(self.client)?;
-                let it = self
-                    .client
-                    .query_raw(stmt, cornucopia_sync::private::slice_iter(&self.params))?
-                    .iterator()
-                    .map(move |res| res.map(|row| (self.mapper)((self.extractor)(&row))));
-                Ok(it)
-            }
+        impl cornucopia_sync::Borrow for Row {
+            type Borrow<'r> = Row;
         }
         #[derive(serde::Serialize, Debug, Clone, PartialEq, Copy)]
         pub struct RowSpace {
             pub id: i32,
         }
-        pub struct RowSpaceQuery<'a, C: GenericClient, T, const N: usize> {
-            client: &'a mut C,
-            params: [&'a (dyn postgres_types::ToSql + Sync); N],
-            stmt: &'a mut cornucopia_sync::private::Stmt,
-            extractor: fn(&postgres::Row) -> RowSpace,
-            mapper: fn(RowSpace) -> T,
-        }
-        impl<'a, C, T: 'a, const N: usize> RowSpaceQuery<'a, C, T, N>
-        where
-            C: GenericClient,
-        {
-            pub fn map<R>(self, mapper: fn(RowSpace) -> R) -> RowSpaceQuery<'a, C, R, N> {
-                RowSpaceQuery {
-                    client: self.client,
-                    params: self.params,
-                    stmt: self.stmt,
-                    extractor: self.extractor,
-                    mapper,
-                }
-            }
-
-            pub fn one(self) -> Result<T, postgres::Error> {
-                let stmt = self.stmt.prepare(self.client)?;
-                let row = self.client.query_one(stmt, &self.params)?;
-                Ok((self.mapper)((self.extractor)(&row)))
-            }
-
-            pub fn all(self) -> Result<Vec<T>, postgres::Error> {
-                self.iter()?.collect()
-            }
-
-            pub fn opt(self) -> Result<Option<T>, postgres::Error> {
-                let stmt = self.stmt.prepare(self.client)?;
-                Ok(self
-                    .client
-                    .query_opt(stmt, &self.params)?
-                    .map(|row| (self.mapper)((self.extractor)(&row))))
-            }
-
-            pub fn iter(
-                self,
-            ) -> Result<impl Iterator<Item = Result<T, postgres::Error>> + 'a, postgres::Error>
-            {
-                let stmt = self.stmt.prepare(self.client)?;
-                let it = self
-                    .client
-                    .query_raw(stmt, cornucopia_sync::private::slice_iter(&self.params))?
-                    .iterator()
-                    .map(move |res| res.map(|row| (self.mapper)((self.extractor)(&row))));
-                Ok(it)
-            }
+        impl cornucopia_sync::Borrow for RowSpace {
+            type Borrow<'r> = RowSpace;
         }
         #[derive(serde::Serialize, Debug, Clone, PartialEq)]
         pub struct Syntax {
@@ -4052,57 +3115,8 @@ pub mod queries {
                 }
             }
         }
-        pub struct SyntaxQuery<'a, C: GenericClient, T, const N: usize> {
-            client: &'a mut C,
-            params: [&'a (dyn postgres_types::ToSql + Sync); N],
-            stmt: &'a mut cornucopia_sync::private::Stmt,
-            extractor: fn(&postgres::Row) -> SyntaxBorrowed,
-            mapper: fn(SyntaxBorrowed) -> T,
-        }
-        impl<'a, C, T: 'a, const N: usize> SyntaxQuery<'a, C, T, N>
-        where
-            C: GenericClient,
-        {
-            pub fn map<R>(self, mapper: fn(SyntaxBorrowed) -> R) -> SyntaxQuery<'a, C, R, N> {
-                SyntaxQuery {
-                    client: self.client,
-                    params: self.params,
-                    stmt: self.stmt,
-                    extractor: self.extractor,
-                    mapper,
-                }
-            }
-
-            pub fn one(self) -> Result<T, postgres::Error> {
-                let stmt = self.stmt.prepare(self.client)?;
-                let row = self.client.query_one(stmt, &self.params)?;
-                Ok((self.mapper)((self.extractor)(&row)))
-            }
-
-            pub fn all(self) -> Result<Vec<T>, postgres::Error> {
-                self.iter()?.collect()
-            }
-
-            pub fn opt(self) -> Result<Option<T>, postgres::Error> {
-                let stmt = self.stmt.prepare(self.client)?;
-                Ok(self
-                    .client
-                    .query_opt(stmt, &self.params)?
-                    .map(|row| (self.mapper)((self.extractor)(&row))))
-            }
-
-            pub fn iter(
-                self,
-            ) -> Result<impl Iterator<Item = Result<T, postgres::Error>> + 'a, postgres::Error>
-            {
-                let stmt = self.stmt.prepare(self.client)?;
-                let it = self
-                    .client
-                    .query_raw(stmt, cornucopia_sync::private::slice_iter(&self.params))?
-                    .iterator()
-                    .map(move |res| res.map(|row| (self.mapper)((self.extractor)(&row))));
-                Ok(it)
-            }
+        impl cornucopia_sync::Borrow for Syntax {
+            type Borrow<'r> = SyntaxBorrowed<'r>;
         }
         pub fn select_compact() -> SelectCompactStmt {
             SelectCompactStmt(cornucopia_sync::private::Stmt::new("SELECT * FROM clone"))
@@ -4112,13 +3126,14 @@ pub mod queries {
             pub fn bind<'a, C: GenericClient>(
                 &'a mut self,
                 client: &'a mut C,
-            ) -> SuperSuperTypesPublicCloneCompositeQuery<
+            ) -> cornucopia_sync::private::Query<
                 'a,
                 C,
                 super::super::types::public::CloneComposite,
+                super::super::types::public::CloneComposite,
                 0,
             > {
-                SuperSuperTypesPublicCloneCompositeQuery {
+                cornucopia_sync::private::Query {
                     client,
                     params: [],
                     stmt: &mut self.0,
@@ -4137,13 +3152,14 @@ pub mod queries {
             pub fn bind<'a, C: GenericClient>(
                 &'a mut self,
                 client: &'a mut C,
-            ) -> SuperSuperTypesPublicCloneCompositeQuery<
+            ) -> cornucopia_sync::private::Query<
                 'a,
                 C,
                 super::super::types::public::CloneComposite,
+                super::super::types::public::CloneComposite,
                 0,
             > {
-                SuperSuperTypesPublicCloneCompositeQuery {
+                cornucopia_sync::private::Query {
                     client,
                     params: [],
                     stmt: &mut self.0,
@@ -4164,8 +3180,8 @@ pub mod queries {
                 client: &'a mut C,
                 name: &'a Option<T1>,
                 price: &'a Option<f64>,
-            ) -> Optioni32Query<'a, C, Option<i32>, 2> {
-                Optioni32Query {
+            ) -> cornucopia_sync::private::Query<'a, C, Option<i32>, Option<i32>, 2> {
+                cornucopia_sync::private::Query {
                     client,
                     params: [name, price],
                     stmt: &mut self.0,
@@ -4178,7 +3194,7 @@ pub mod queries {
             cornucopia_sync::Params<
                 'a,
                 ImplicitCompactParams<T1>,
-                Optioni32Query<'a, C, Option<i32>, 2>,
+                cornucopia_sync::private::Query<'a, C, Option<i32>, Option<i32>, 2>,
                 C,
             > for ImplicitCompactStmt
         {
@@ -4186,7 +3202,7 @@ pub mod queries {
                 &'a mut self,
                 client: &'a mut C,
                 params: &'a ImplicitCompactParams<T1>,
-            ) -> Optioni32Query<'a, C, Option<i32>, 2> {
+            ) -> cornucopia_sync::private::Query<'a, C, Option<i32>, Option<i32>, 2> {
                 self.bind(client, &params.name, &params.price)
             }
         }
@@ -4202,8 +3218,8 @@ pub mod queries {
                 client: &'a mut C,
                 name: &'a Option<T1>,
                 price: &'a Option<f64>,
-            ) -> Optioni32Query<'a, C, Option<i32>, 2> {
-                Optioni32Query {
+            ) -> cornucopia_sync::private::Query<'a, C, Option<i32>, Option<i32>, 2> {
+                cornucopia_sync::private::Query {
                     client,
                     params: [name, price],
                     stmt: &mut self.0,
@@ -4216,7 +3232,7 @@ pub mod queries {
             cornucopia_sync::Params<
                 'a,
                 ImplicitSpacedParams<T1>,
-                Optioni32Query<'a, C, Option<i32>, 2>,
+                cornucopia_sync::private::Query<'a, C, Option<i32>, Option<i32>, 2>,
                 C,
             > for ImplicitSpacedStmt
         {
@@ -4224,7 +3240,7 @@ pub mod queries {
                 &'a mut self,
                 client: &'a mut C,
                 params: &'a ImplicitSpacedParams<T1>,
-            ) -> Optioni32Query<'a, C, Option<i32>, 2> {
+            ) -> cornucopia_sync::private::Query<'a, C, Option<i32>, Option<i32>, 2> {
                 self.bind(client, &params.name, &params.price)
             }
         }
@@ -4240,8 +3256,8 @@ pub mod queries {
                 client: &'a mut C,
                 name: &'a T1,
                 price: &'a f64,
-            ) -> RowQuery<'a, C, Row, 2> {
-                RowQuery {
+            ) -> cornucopia_sync::private::Query<'a, C, Row, Row, 2> {
+                cornucopia_sync::private::Query {
                     client,
                     params: [name, price],
                     stmt: &mut self.0,
@@ -4251,14 +3267,18 @@ pub mod queries {
             }
         }
         impl<'a, C: GenericClient, T1: cornucopia_sync::StringSql>
-            cornucopia_sync::Params<'a, Params<T1>, RowQuery<'a, C, Row, 2>, C>
-            for NamedCompactStmt
+            cornucopia_sync::Params<
+                'a,
+                Params<T1>,
+                cornucopia_sync::private::Query<'a, C, Row, Row, 2>,
+                C,
+            > for NamedCompactStmt
         {
             fn params(
                 &'a mut self,
                 client: &'a mut C,
                 params: &'a Params<T1>,
-            ) -> RowQuery<'a, C, Row, 2> {
+            ) -> cornucopia_sync::private::Query<'a, C, Row, Row, 2> {
                 self.bind(client, &params.name, &params.price)
             }
         }
@@ -4274,8 +3294,8 @@ pub mod queries {
                 client: &'a mut C,
                 name: &'a T1,
                 price: &'a f64,
-            ) -> RowSpaceQuery<'a, C, RowSpace, 2> {
-                RowSpaceQuery {
+            ) -> cornucopia_sync::private::Query<'a, C, RowSpace, RowSpace, 2> {
+                cornucopia_sync::private::Query {
                     client,
                     params: [name, price],
                     stmt: &mut self.0,
@@ -4285,14 +3305,18 @@ pub mod queries {
             }
         }
         impl<'a, C: GenericClient, T1: cornucopia_sync::StringSql>
-            cornucopia_sync::Params<'a, ParamsSpace<T1>, RowSpaceQuery<'a, C, RowSpace, 2>, C>
-            for NamedSpacedStmt
+            cornucopia_sync::Params<
+                'a,
+                ParamsSpace<T1>,
+                cornucopia_sync::private::Query<'a, C, RowSpace, RowSpace, 2>,
+                C,
+            > for NamedSpacedStmt
         {
             fn params(
                 &'a mut self,
                 client: &'a mut C,
                 params: &'a ParamsSpace<T1>,
-            ) -> RowSpaceQuery<'a, C, RowSpace, 2> {
+            ) -> cornucopia_sync::private::Query<'a, C, RowSpace, RowSpace, 2> {
                 self.bind(client, &params.name, &params.price)
             }
         }
@@ -4450,8 +3474,8 @@ pub mod queries {
             pub fn bind<'a, C: GenericClient>(
                 &'a mut self,
                 client: &'a mut C,
-            ) -> SyntaxQuery<'a, C, Syntax, 0> {
-                SyntaxQuery {
+            ) -> cornucopia_sync::private::Query<'a, C, Syntax, Syntax, 0> {
+                cornucopia_sync::private::Query {
                     client,
                     params: [],
                     stmt: &mut self.0,

--- a/codegen_test/src/main.rs
+++ b/codegen_test/src/main.rs
@@ -1,3 +1,5 @@
+#![feature(generic_associated_types)]
+
 mod cornucopia_async;
 mod cornucopia_sync;
 

--- a/cornucopia/src/container.rs
+++ b/cornucopia/src/container.rs
@@ -47,7 +47,7 @@ fn spawn_container(podman: bool) -> Result<(), Error> {
 /// Checks if Cornucopia's container reports healthy
 fn is_postgres_healthy(podman: bool) -> Result<bool, Error> {
     let command = if podman { "podman" } else { "docker" };
-    Ok(Command::new(&command)
+    Ok(Command::new(command)
         .arg("exec")
         .arg("cornucopia_postgres")
         .arg("pg_isready")
@@ -96,7 +96,7 @@ fn healthcheck(podman: bool, max_retries: u64, ms_per_retry: u64) -> Result<(), 
 /// Stops Cornucopia's container.
 fn stop_container(podman: bool) -> Result<(), Error> {
     let command = if podman { "podman" } else { "docker" };
-    let success = Command::new(&command)
+    let success = Command::new(command)
         .arg("stop")
         .arg("cornucopia_postgres")
         .stderr(Stdio::null())
@@ -117,7 +117,7 @@ fn stop_container(podman: bool) -> Result<(), Error> {
 /// Removes Cornucopia's container and its volume.
 fn remove_container(podman: bool) -> Result<(), Error> {
     let command = if podman { "podman" } else { "docker" };
-    let success = Command::new(&command)
+    let success = Command::new(command)
         .arg("rm")
         .arg("-v")
         .arg("cornucopia_postgres")

--- a/cornucopia/src/parser.rs
+++ b/cornucopia/src/parser.rs
@@ -290,7 +290,7 @@ impl QueryDataStruct {
                     || {
                         registered_structs
                             .iter()
-                            .find_map(|it| (it.name == *named).then(|| it.fields.as_slice()))
+                            .find_map(|it| (it.name == *named).then_some(it.fields.as_slice()))
                             .unwrap_or(&[])
                     },
                     Vec::as_slice,

--- a/cornucopia/src/validation.rs
+++ b/cornucopia/src/validation.rs
@@ -231,7 +231,7 @@ pub(crate) fn named_struct_field(
     if let Some((field, prev_field)) = fields.iter().find_map(|f| {
         prev_fields
             .iter()
-            .find_map(|prev_f| (f.name == prev_f.name && f.ty != prev_f.ty).then(|| (f, prev_f)))
+            .find_map(|prev_f| (f.name == prev_f.name && f.ty != prev_f.ty).then_some((f, prev_f)))
     }) {
         return Err(Error::IncompatibleNamedType {
             src: info.into(),

--- a/examples/auto_build/src/cornucopia.rs
+++ b/examples/auto_build/src/cornucopia.rs
@@ -14,62 +14,6 @@ pub mod queries {
         use cornucopia_async::GenericClient;
         use futures;
         use futures::{StreamExt, TryStreamExt};
-        pub struct StringQuery<'a, C: GenericClient, T, const N: usize> {
-            client: &'a C,
-            params: [&'a (dyn postgres_types::ToSql + Sync); N],
-            stmt: &'a mut cornucopia_async::private::Stmt,
-            extractor: fn(&tokio_postgres::Row) -> &str,
-            mapper: fn(&str) -> T,
-        }
-        impl<'a, C, T: 'a, const N: usize> StringQuery<'a, C, T, N>
-        where
-            C: GenericClient,
-        {
-            pub fn map<R>(self, mapper: fn(&str) -> R) -> StringQuery<'a, C, R, N> {
-                StringQuery {
-                    client: self.client,
-                    params: self.params,
-                    stmt: self.stmt,
-                    extractor: self.extractor,
-                    mapper,
-                }
-            }
-
-            pub async fn one(self) -> Result<T, tokio_postgres::Error> {
-                let stmt = self.stmt.prepare(self.client).await?;
-                let row = self.client.query_one(stmt, &self.params).await?;
-                Ok((self.mapper)((self.extractor)(&row)))
-            }
-
-            pub async fn all(self) -> Result<Vec<T>, tokio_postgres::Error> {
-                self.iter().await?.try_collect().await
-            }
-
-            pub async fn opt(self) -> Result<Option<T>, tokio_postgres::Error> {
-                let stmt = self.stmt.prepare(self.client).await?;
-                Ok(self
-                    .client
-                    .query_opt(stmt, &self.params)
-                    .await?
-                    .map(|row| (self.mapper)((self.extractor)(&row))))
-            }
-
-            pub async fn iter(
-                self,
-            ) -> Result<
-                impl futures::Stream<Item = Result<T, tokio_postgres::Error>> + 'a,
-                tokio_postgres::Error,
-            > {
-                let stmt = self.stmt.prepare(self.client).await?;
-                let it = self
-                    .client
-                    .query_raw(stmt, cornucopia_async::private::slice_iter(&self.params))
-                    .await?
-                    .map(move |res| res.map(|row| (self.mapper)((self.extractor)(&row))))
-                    .into_stream();
-                Ok(it)
-            }
-        }
         pub fn example_query() -> ExampleQueryStmt {
             ExampleQueryStmt(cornucopia_async::private::Stmt::new(
                 "SELECT
@@ -83,8 +27,8 @@ FROM
             pub fn bind<'a, C: GenericClient>(
                 &'a mut self,
                 client: &'a C,
-            ) -> StringQuery<'a, C, String, 0> {
-                StringQuery {
+            ) -> cornucopia_async::private::Query<'a, C, String, String, 0> {
+                cornucopia_async::private::Query {
                     client,
                     params: [],
                     stmt: &mut self.0,

--- a/examples/auto_build/src/main.rs
+++ b/examples/auto_build/src/main.rs
@@ -1,3 +1,5 @@
+#![feature(generic_associated_types)]
+
 use deadpool_postgres::{Config, Runtime};
 use tokio_postgres::NoTls;
 

--- a/examples/basic_async/src/cornucopia.rs
+++ b/examples/basic_async/src/cornucopia.rs
@@ -15,6 +15,9 @@ pub mod types {
             Patrick,
             Squidward,
         }
+        impl cornucopia_async::Borrow for SpongebobCharacter {
+            type Borrow<'r> = SpongebobCharacter;
+        }
     }
 }
 #[allow(clippy::all, clippy::pedantic)]
@@ -72,119 +75,10 @@ pub mod queries {
                 }
             }
         }
-        pub struct AuthorsQuery<'a, C: GenericClient, T, const N: usize> {
-            client: &'a C,
-            params: [&'a (dyn postgres_types::ToSql + Sync); N],
-            stmt: &'a mut cornucopia_async::private::Stmt,
-            extractor: fn(&tokio_postgres::Row) -> AuthorsBorrowed,
-            mapper: fn(AuthorsBorrowed) -> T,
-        }
-        impl<'a, C, T: 'a, const N: usize> AuthorsQuery<'a, C, T, N>
-        where
-            C: GenericClient,
-        {
-            pub fn map<R>(self, mapper: fn(AuthorsBorrowed) -> R) -> AuthorsQuery<'a, C, R, N> {
-                AuthorsQuery {
-                    client: self.client,
-                    params: self.params,
-                    stmt: self.stmt,
-                    extractor: self.extractor,
-                    mapper,
-                }
-            }
-
-            pub async fn one(self) -> Result<T, tokio_postgres::Error> {
-                let stmt = self.stmt.prepare(self.client).await?;
-                let row = self.client.query_one(stmt, &self.params).await?;
-                Ok((self.mapper)((self.extractor)(&row)))
-            }
-
-            pub async fn all(self) -> Result<Vec<T>, tokio_postgres::Error> {
-                self.iter().await?.try_collect().await
-            }
-
-            pub async fn opt(self) -> Result<Option<T>, tokio_postgres::Error> {
-                let stmt = self.stmt.prepare(self.client).await?;
-                Ok(self
-                    .client
-                    .query_opt(stmt, &self.params)
-                    .await?
-                    .map(|row| (self.mapper)((self.extractor)(&row))))
-            }
-
-            pub async fn iter(
-                self,
-            ) -> Result<
-                impl futures::Stream<Item = Result<T, tokio_postgres::Error>> + 'a,
-                tokio_postgres::Error,
-            > {
-                let stmt = self.stmt.prepare(self.client).await?;
-                let it = self
-                    .client
-                    .query_raw(stmt, cornucopia_async::private::slice_iter(&self.params))
-                    .await?
-                    .map(move |res| res.map(|row| (self.mapper)((self.extractor)(&row))))
-                    .into_stream();
-                Ok(it)
-            }
+        impl cornucopia_async::Borrow for Authors {
+            type Borrow<'r> = AuthorsBorrowed<'r>;
         }
 
-        pub struct StringQuery<'a, C: GenericClient, T, const N: usize> {
-            client: &'a C,
-            params: [&'a (dyn postgres_types::ToSql + Sync); N],
-            stmt: &'a mut cornucopia_async::private::Stmt,
-            extractor: fn(&tokio_postgres::Row) -> &str,
-            mapper: fn(&str) -> T,
-        }
-        impl<'a, C, T: 'a, const N: usize> StringQuery<'a, C, T, N>
-        where
-            C: GenericClient,
-        {
-            pub fn map<R>(self, mapper: fn(&str) -> R) -> StringQuery<'a, C, R, N> {
-                StringQuery {
-                    client: self.client,
-                    params: self.params,
-                    stmt: self.stmt,
-                    extractor: self.extractor,
-                    mapper,
-                }
-            }
-
-            pub async fn one(self) -> Result<T, tokio_postgres::Error> {
-                let stmt = self.stmt.prepare(self.client).await?;
-                let row = self.client.query_one(stmt, &self.params).await?;
-                Ok((self.mapper)((self.extractor)(&row)))
-            }
-
-            pub async fn all(self) -> Result<Vec<T>, tokio_postgres::Error> {
-                self.iter().await?.try_collect().await
-            }
-
-            pub async fn opt(self) -> Result<Option<T>, tokio_postgres::Error> {
-                let stmt = self.stmt.prepare(self.client).await?;
-                Ok(self
-                    .client
-                    .query_opt(stmt, &self.params)
-                    .await?
-                    .map(|row| (self.mapper)((self.extractor)(&row))))
-            }
-
-            pub async fn iter(
-                self,
-            ) -> Result<
-                impl futures::Stream<Item = Result<T, tokio_postgres::Error>> + 'a,
-                tokio_postgres::Error,
-            > {
-                let stmt = self.stmt.prepare(self.client).await?;
-                let it = self
-                    .client
-                    .query_raw(stmt, cornucopia_async::private::slice_iter(&self.params))
-                    .await?
-                    .map(move |res| res.map(|row| (self.mapper)((self.extractor)(&row))))
-                    .into_stream();
-                Ok(it)
-            }
-        }
         #[derive(Debug, Clone, PartialEq)]
         pub struct AuthorNameStartingWith {
             pub authorid: i32,
@@ -215,130 +109,10 @@ pub mod queries {
                 }
             }
         }
-        pub struct AuthorNameStartingWithQuery<'a, C: GenericClient, T, const N: usize> {
-            client: &'a C,
-            params: [&'a (dyn postgres_types::ToSql + Sync); N],
-            stmt: &'a mut cornucopia_async::private::Stmt,
-            extractor: fn(&tokio_postgres::Row) -> AuthorNameStartingWithBorrowed,
-            mapper: fn(AuthorNameStartingWithBorrowed) -> T,
-        }
-        impl<'a, C, T: 'a, const N: usize> AuthorNameStartingWithQuery<'a, C, T, N>
-        where
-            C: GenericClient,
-        {
-            pub fn map<R>(
-                self,
-                mapper: fn(AuthorNameStartingWithBorrowed) -> R,
-            ) -> AuthorNameStartingWithQuery<'a, C, R, N> {
-                AuthorNameStartingWithQuery {
-                    client: self.client,
-                    params: self.params,
-                    stmt: self.stmt,
-                    extractor: self.extractor,
-                    mapper,
-                }
-            }
-
-            pub async fn one(self) -> Result<T, tokio_postgres::Error> {
-                let stmt = self.stmt.prepare(self.client).await?;
-                let row = self.client.query_one(stmt, &self.params).await?;
-                Ok((self.mapper)((self.extractor)(&row)))
-            }
-
-            pub async fn all(self) -> Result<Vec<T>, tokio_postgres::Error> {
-                self.iter().await?.try_collect().await
-            }
-
-            pub async fn opt(self) -> Result<Option<T>, tokio_postgres::Error> {
-                let stmt = self.stmt.prepare(self.client).await?;
-                Ok(self
-                    .client
-                    .query_opt(stmt, &self.params)
-                    .await?
-                    .map(|row| (self.mapper)((self.extractor)(&row))))
-            }
-
-            pub async fn iter(
-                self,
-            ) -> Result<
-                impl futures::Stream<Item = Result<T, tokio_postgres::Error>> + 'a,
-                tokio_postgres::Error,
-            > {
-                let stmt = self.stmt.prepare(self.client).await?;
-                let it = self
-                    .client
-                    .query_raw(stmt, cornucopia_async::private::slice_iter(&self.params))
-                    .await?
-                    .map(move |res| res.map(|row| (self.mapper)((self.extractor)(&row))))
-                    .into_stream();
-                Ok(it)
-            }
+        impl cornucopia_async::Borrow for AuthorNameStartingWith {
+            type Borrow<'r> = AuthorNameStartingWithBorrowed<'r>;
         }
 
-        pub struct SuperSuperTypesPublicSpongebobCharacterQuery<
-            'a,
-            C: GenericClient,
-            T,
-            const N: usize,
-        > {
-            client: &'a C,
-            params: [&'a (dyn postgres_types::ToSql + Sync); N],
-            stmt: &'a mut cornucopia_async::private::Stmt,
-            extractor: fn(&tokio_postgres::Row) -> super::super::types::public::SpongebobCharacter,
-            mapper: fn(super::super::types::public::SpongebobCharacter) -> T,
-        }
-        impl<'a, C, T: 'a, const N: usize> SuperSuperTypesPublicSpongebobCharacterQuery<'a, C, T, N>
-        where
-            C: GenericClient,
-        {
-            pub fn map<R>(
-                self,
-                mapper: fn(super::super::types::public::SpongebobCharacter) -> R,
-            ) -> SuperSuperTypesPublicSpongebobCharacterQuery<'a, C, R, N> {
-                SuperSuperTypesPublicSpongebobCharacterQuery {
-                    client: self.client,
-                    params: self.params,
-                    stmt: self.stmt,
-                    extractor: self.extractor,
-                    mapper,
-                }
-            }
-
-            pub async fn one(self) -> Result<T, tokio_postgres::Error> {
-                let stmt = self.stmt.prepare(self.client).await?;
-                let row = self.client.query_one(stmt, &self.params).await?;
-                Ok((self.mapper)((self.extractor)(&row)))
-            }
-
-            pub async fn all(self) -> Result<Vec<T>, tokio_postgres::Error> {
-                self.iter().await?.try_collect().await
-            }
-
-            pub async fn opt(self) -> Result<Option<T>, tokio_postgres::Error> {
-                let stmt = self.stmt.prepare(self.client).await?;
-                Ok(self
-                    .client
-                    .query_opt(stmt, &self.params)
-                    .await?
-                    .map(|row| (self.mapper)((self.extractor)(&row))))
-            }
-
-            pub async fn iter(
-                self,
-            ) -> Result<
-                impl futures::Stream<Item = Result<T, tokio_postgres::Error>> + 'a,
-                tokio_postgres::Error,
-            > {
-                let stmt = self.stmt.prepare(self.client).await?;
-                let it = self
-                    .client
-                    .query_raw(stmt, cornucopia_async::private::slice_iter(&self.params))
-                    .await?
-                    .map(move |res| res.map(|row| (self.mapper)((self.extractor)(&row))))
-                    .into_stream();
-                Ok(it)
-            }
-        }
         #[derive(Debug, Clone, PartialEq)]
         pub struct SelectTranslations {
             pub title: String,
@@ -361,64 +135,8 @@ pub mod queries {
                 }
             }
         }
-        pub struct SelectTranslationsQuery<'a, C: GenericClient, T, const N: usize> {
-            client: &'a C,
-            params: [&'a (dyn postgres_types::ToSql + Sync); N],
-            stmt: &'a mut cornucopia_async::private::Stmt,
-            extractor: fn(&tokio_postgres::Row) -> SelectTranslationsBorrowed,
-            mapper: fn(SelectTranslationsBorrowed) -> T,
-        }
-        impl<'a, C, T: 'a, const N: usize> SelectTranslationsQuery<'a, C, T, N>
-        where
-            C: GenericClient,
-        {
-            pub fn map<R>(
-                self,
-                mapper: fn(SelectTranslationsBorrowed) -> R,
-            ) -> SelectTranslationsQuery<'a, C, R, N> {
-                SelectTranslationsQuery {
-                    client: self.client,
-                    params: self.params,
-                    stmt: self.stmt,
-                    extractor: self.extractor,
-                    mapper,
-                }
-            }
-
-            pub async fn one(self) -> Result<T, tokio_postgres::Error> {
-                let stmt = self.stmt.prepare(self.client).await?;
-                let row = self.client.query_one(stmt, &self.params).await?;
-                Ok((self.mapper)((self.extractor)(&row)))
-            }
-
-            pub async fn all(self) -> Result<Vec<T>, tokio_postgres::Error> {
-                self.iter().await?.try_collect().await
-            }
-
-            pub async fn opt(self) -> Result<Option<T>, tokio_postgres::Error> {
-                let stmt = self.stmt.prepare(self.client).await?;
-                Ok(self
-                    .client
-                    .query_opt(stmt, &self.params)
-                    .await?
-                    .map(|row| (self.mapper)((self.extractor)(&row))))
-            }
-
-            pub async fn iter(
-                self,
-            ) -> Result<
-                impl futures::Stream<Item = Result<T, tokio_postgres::Error>> + 'a,
-                tokio_postgres::Error,
-            > {
-                let stmt = self.stmt.prepare(self.client).await?;
-                let it = self
-                    .client
-                    .query_raw(stmt, cornucopia_async::private::slice_iter(&self.params))
-                    .await?
-                    .map(move |res| res.map(|row| (self.mapper)((self.extractor)(&row))))
-                    .into_stream();
-                Ok(it)
-            }
+        impl cornucopia_async::Borrow for SelectTranslations {
+            type Borrow<'r> = SelectTranslationsBorrowed<'r>;
         }
         pub fn authors() -> AuthorsStmt {
             AuthorsStmt(cornucopia_async::private::Stmt::new(
@@ -433,8 +151,8 @@ FROM
             pub fn bind<'a, C: GenericClient>(
                 &'a mut self,
                 client: &'a C,
-            ) -> AuthorsQuery<'a, C, Authors, 0> {
-                AuthorsQuery {
+            ) -> cornucopia_async::private::Query<'a, C, Authors, Authors, 0> {
+                cornucopia_async::private::Query {
                     client,
                     params: [],
                     stmt: &mut self.0,
@@ -460,8 +178,8 @@ FROM
             pub fn bind<'a, C: GenericClient>(
                 &'a mut self,
                 client: &'a C,
-            ) -> StringQuery<'a, C, String, 0> {
-                StringQuery {
+            ) -> cornucopia_async::private::Query<'a, C, String, String, 0> {
+                cornucopia_async::private::Query {
                     client,
                     params: [],
                     stmt: &mut self.0,
@@ -486,8 +204,8 @@ WHERE
                 &'a mut self,
                 client: &'a C,
                 id: &'a i32,
-            ) -> StringQuery<'a, C, String, 1> {
-                StringQuery {
+            ) -> cornucopia_async::private::Query<'a, C, String, String, 1> {
+                cornucopia_async::private::Query {
                     client,
                     params: [id],
                     stmt: &mut self.0,
@@ -517,8 +235,14 @@ WHERE
                 &'a mut self,
                 client: &'a C,
                 start_str: &'a T1,
-            ) -> AuthorNameStartingWithQuery<'a, C, AuthorNameStartingWith, 1> {
-                AuthorNameStartingWithQuery {
+            ) -> cornucopia_async::private::Query<
+                'a,
+                C,
+                AuthorNameStartingWith,
+                AuthorNameStartingWith,
+                1,
+            > {
+                cornucopia_async::private::Query {
                     client,
                     params: [start_str],
                     stmt: &mut self.0,
@@ -536,7 +260,13 @@ WHERE
             cornucopia_async::Params<
                 'a,
                 AuthorNameStartingWithParams<T1>,
-                AuthorNameStartingWithQuery<'a, C, AuthorNameStartingWith, 1>,
+                cornucopia_async::private::Query<
+                    'a,
+                    C,
+                    AuthorNameStartingWith,
+                    AuthorNameStartingWith,
+                    1,
+                >,
                 C,
             > for AuthorNameStartingWithStmt
         {
@@ -544,7 +274,13 @@ WHERE
                 &'a mut self,
                 client: &'a C,
                 params: &'a AuthorNameStartingWithParams<T1>,
-            ) -> AuthorNameStartingWithQuery<'a, C, AuthorNameStartingWith, 1> {
+            ) -> cornucopia_async::private::Query<
+                'a,
+                C,
+                AuthorNameStartingWith,
+                AuthorNameStartingWith,
+                1,
+            > {
                 self.bind(client, &params.start_str)
             }
         }
@@ -563,13 +299,14 @@ WHERE (col1).persona = $1",
                 &'a mut self,
                 client: &'a C,
                 spongebob_character: &'a super::super::types::public::SpongebobCharacter,
-            ) -> SuperSuperTypesPublicSpongebobCharacterQuery<
+            ) -> cornucopia_async::private::Query<
                 'a,
                 C,
                 super::super::types::public::SpongebobCharacter,
+                super::super::types::public::SpongebobCharacter,
                 1,
             > {
-                SuperSuperTypesPublicSpongebobCharacterQuery {
+                cornucopia_async::private::Query {
                     client,
                     params: [spongebob_character],
                     stmt: &mut self.0,
@@ -592,8 +329,9 @@ FROM
             pub fn bind<'a, C: GenericClient>(
                 &'a mut self,
                 client: &'a C,
-            ) -> SelectTranslationsQuery<'a, C, SelectTranslations, 0> {
-                SelectTranslationsQuery {
+            ) -> cornucopia_async::private::Query<'a, C, SelectTranslations, SelectTranslations, 0>
+            {
+                cornucopia_async::private::Query {
                     client,
                     params: [],
                     stmt: &mut self.0,

--- a/examples/basic_async/src/main.rs
+++ b/examples/basic_async/src/main.rs
@@ -1,3 +1,5 @@
+#![feature(generic_associated_types)]
+
 // Take a look at the generated `cornucopia.rs` file if you want to
 // see what it looks like under the hood.
 mod cornucopia;

--- a/examples/basic_sync/src/cornucopia.rs
+++ b/examples/basic_sync/src/cornucopia.rs
@@ -15,6 +15,9 @@ pub mod types {
             Patrick,
             Squidward,
         }
+        impl cornucopia_sync::Borrow for SpongebobCharacter {
+            type Borrow<'r> = SpongebobCharacter;
+        }
     }
 }
 #[allow(clippy::all, clippy::pedantic)]
@@ -68,111 +71,10 @@ pub mod queries {
                 }
             }
         }
-        pub struct AuthorsQuery<'a, C: GenericClient, T, const N: usize> {
-            client: &'a mut C,
-            params: [&'a (dyn postgres_types::ToSql + Sync); N],
-            stmt: &'a mut cornucopia_sync::private::Stmt,
-            extractor: fn(&postgres::Row) -> AuthorsBorrowed,
-            mapper: fn(AuthorsBorrowed) -> T,
-        }
-        impl<'a, C, T: 'a, const N: usize> AuthorsQuery<'a, C, T, N>
-        where
-            C: GenericClient,
-        {
-            pub fn map<R>(self, mapper: fn(AuthorsBorrowed) -> R) -> AuthorsQuery<'a, C, R, N> {
-                AuthorsQuery {
-                    client: self.client,
-                    params: self.params,
-                    stmt: self.stmt,
-                    extractor: self.extractor,
-                    mapper,
-                }
-            }
-
-            pub fn one(self) -> Result<T, postgres::Error> {
-                let stmt = self.stmt.prepare(self.client)?;
-                let row = self.client.query_one(stmt, &self.params)?;
-                Ok((self.mapper)((self.extractor)(&row)))
-            }
-
-            pub fn all(self) -> Result<Vec<T>, postgres::Error> {
-                self.iter()?.collect()
-            }
-
-            pub fn opt(self) -> Result<Option<T>, postgres::Error> {
-                let stmt = self.stmt.prepare(self.client)?;
-                Ok(self
-                    .client
-                    .query_opt(stmt, &self.params)?
-                    .map(|row| (self.mapper)((self.extractor)(&row))))
-            }
-
-            pub fn iter(
-                self,
-            ) -> Result<impl Iterator<Item = Result<T, postgres::Error>> + 'a, postgres::Error>
-            {
-                let stmt = self.stmt.prepare(self.client)?;
-                let it = self
-                    .client
-                    .query_raw(stmt, cornucopia_sync::private::slice_iter(&self.params))?
-                    .iterator()
-                    .map(move |res| res.map(|row| (self.mapper)((self.extractor)(&row))));
-                Ok(it)
-            }
+        impl cornucopia_sync::Borrow for Authors {
+            type Borrow<'r> = AuthorsBorrowed<'r>;
         }
 
-        pub struct StringQuery<'a, C: GenericClient, T, const N: usize> {
-            client: &'a mut C,
-            params: [&'a (dyn postgres_types::ToSql + Sync); N],
-            stmt: &'a mut cornucopia_sync::private::Stmt,
-            extractor: fn(&postgres::Row) -> &str,
-            mapper: fn(&str) -> T,
-        }
-        impl<'a, C, T: 'a, const N: usize> StringQuery<'a, C, T, N>
-        where
-            C: GenericClient,
-        {
-            pub fn map<R>(self, mapper: fn(&str) -> R) -> StringQuery<'a, C, R, N> {
-                StringQuery {
-                    client: self.client,
-                    params: self.params,
-                    stmt: self.stmt,
-                    extractor: self.extractor,
-                    mapper,
-                }
-            }
-
-            pub fn one(self) -> Result<T, postgres::Error> {
-                let stmt = self.stmt.prepare(self.client)?;
-                let row = self.client.query_one(stmt, &self.params)?;
-                Ok((self.mapper)((self.extractor)(&row)))
-            }
-
-            pub fn all(self) -> Result<Vec<T>, postgres::Error> {
-                self.iter()?.collect()
-            }
-
-            pub fn opt(self) -> Result<Option<T>, postgres::Error> {
-                let stmt = self.stmt.prepare(self.client)?;
-                Ok(self
-                    .client
-                    .query_opt(stmt, &self.params)?
-                    .map(|row| (self.mapper)((self.extractor)(&row))))
-            }
-
-            pub fn iter(
-                self,
-            ) -> Result<impl Iterator<Item = Result<T, postgres::Error>> + 'a, postgres::Error>
-            {
-                let stmt = self.stmt.prepare(self.client)?;
-                let it = self
-                    .client
-                    .query_raw(stmt, cornucopia_sync::private::slice_iter(&self.params))?
-                    .iterator()
-                    .map(move |res| res.map(|row| (self.mapper)((self.extractor)(&row))));
-                Ok(it)
-            }
-        }
         #[derive(Debug, Clone, PartialEq)]
         pub struct AuthorNameStartingWith {
             pub authorid: i32,
@@ -203,122 +105,10 @@ pub mod queries {
                 }
             }
         }
-        pub struct AuthorNameStartingWithQuery<'a, C: GenericClient, T, const N: usize> {
-            client: &'a mut C,
-            params: [&'a (dyn postgres_types::ToSql + Sync); N],
-            stmt: &'a mut cornucopia_sync::private::Stmt,
-            extractor: fn(&postgres::Row) -> AuthorNameStartingWithBorrowed,
-            mapper: fn(AuthorNameStartingWithBorrowed) -> T,
-        }
-        impl<'a, C, T: 'a, const N: usize> AuthorNameStartingWithQuery<'a, C, T, N>
-        where
-            C: GenericClient,
-        {
-            pub fn map<R>(
-                self,
-                mapper: fn(AuthorNameStartingWithBorrowed) -> R,
-            ) -> AuthorNameStartingWithQuery<'a, C, R, N> {
-                AuthorNameStartingWithQuery {
-                    client: self.client,
-                    params: self.params,
-                    stmt: self.stmt,
-                    extractor: self.extractor,
-                    mapper,
-                }
-            }
-
-            pub fn one(self) -> Result<T, postgres::Error> {
-                let stmt = self.stmt.prepare(self.client)?;
-                let row = self.client.query_one(stmt, &self.params)?;
-                Ok((self.mapper)((self.extractor)(&row)))
-            }
-
-            pub fn all(self) -> Result<Vec<T>, postgres::Error> {
-                self.iter()?.collect()
-            }
-
-            pub fn opt(self) -> Result<Option<T>, postgres::Error> {
-                let stmt = self.stmt.prepare(self.client)?;
-                Ok(self
-                    .client
-                    .query_opt(stmt, &self.params)?
-                    .map(|row| (self.mapper)((self.extractor)(&row))))
-            }
-
-            pub fn iter(
-                self,
-            ) -> Result<impl Iterator<Item = Result<T, postgres::Error>> + 'a, postgres::Error>
-            {
-                let stmt = self.stmt.prepare(self.client)?;
-                let it = self
-                    .client
-                    .query_raw(stmt, cornucopia_sync::private::slice_iter(&self.params))?
-                    .iterator()
-                    .map(move |res| res.map(|row| (self.mapper)((self.extractor)(&row))));
-                Ok(it)
-            }
+        impl cornucopia_sync::Borrow for AuthorNameStartingWith {
+            type Borrow<'r> = AuthorNameStartingWithBorrowed<'r>;
         }
 
-        pub struct SuperSuperTypesPublicSpongebobCharacterQuery<
-            'a,
-            C: GenericClient,
-            T,
-            const N: usize,
-        > {
-            client: &'a mut C,
-            params: [&'a (dyn postgres_types::ToSql + Sync); N],
-            stmt: &'a mut cornucopia_sync::private::Stmt,
-            extractor: fn(&postgres::Row) -> super::super::types::public::SpongebobCharacter,
-            mapper: fn(super::super::types::public::SpongebobCharacter) -> T,
-        }
-        impl<'a, C, T: 'a, const N: usize> SuperSuperTypesPublicSpongebobCharacterQuery<'a, C, T, N>
-        where
-            C: GenericClient,
-        {
-            pub fn map<R>(
-                self,
-                mapper: fn(super::super::types::public::SpongebobCharacter) -> R,
-            ) -> SuperSuperTypesPublicSpongebobCharacterQuery<'a, C, R, N> {
-                SuperSuperTypesPublicSpongebobCharacterQuery {
-                    client: self.client,
-                    params: self.params,
-                    stmt: self.stmt,
-                    extractor: self.extractor,
-                    mapper,
-                }
-            }
-
-            pub fn one(self) -> Result<T, postgres::Error> {
-                let stmt = self.stmt.prepare(self.client)?;
-                let row = self.client.query_one(stmt, &self.params)?;
-                Ok((self.mapper)((self.extractor)(&row)))
-            }
-
-            pub fn all(self) -> Result<Vec<T>, postgres::Error> {
-                self.iter()?.collect()
-            }
-
-            pub fn opt(self) -> Result<Option<T>, postgres::Error> {
-                let stmt = self.stmt.prepare(self.client)?;
-                Ok(self
-                    .client
-                    .query_opt(stmt, &self.params)?
-                    .map(|row| (self.mapper)((self.extractor)(&row))))
-            }
-
-            pub fn iter(
-                self,
-            ) -> Result<impl Iterator<Item = Result<T, postgres::Error>> + 'a, postgres::Error>
-            {
-                let stmt = self.stmt.prepare(self.client)?;
-                let it = self
-                    .client
-                    .query_raw(stmt, cornucopia_sync::private::slice_iter(&self.params))?
-                    .iterator()
-                    .map(move |res| res.map(|row| (self.mapper)((self.extractor)(&row))));
-                Ok(it)
-            }
-        }
         #[derive(Debug, Clone, PartialEq)]
         pub struct SelectTranslations {
             pub title: String,
@@ -341,60 +131,8 @@ pub mod queries {
                 }
             }
         }
-        pub struct SelectTranslationsQuery<'a, C: GenericClient, T, const N: usize> {
-            client: &'a mut C,
-            params: [&'a (dyn postgres_types::ToSql + Sync); N],
-            stmt: &'a mut cornucopia_sync::private::Stmt,
-            extractor: fn(&postgres::Row) -> SelectTranslationsBorrowed,
-            mapper: fn(SelectTranslationsBorrowed) -> T,
-        }
-        impl<'a, C, T: 'a, const N: usize> SelectTranslationsQuery<'a, C, T, N>
-        where
-            C: GenericClient,
-        {
-            pub fn map<R>(
-                self,
-                mapper: fn(SelectTranslationsBorrowed) -> R,
-            ) -> SelectTranslationsQuery<'a, C, R, N> {
-                SelectTranslationsQuery {
-                    client: self.client,
-                    params: self.params,
-                    stmt: self.stmt,
-                    extractor: self.extractor,
-                    mapper,
-                }
-            }
-
-            pub fn one(self) -> Result<T, postgres::Error> {
-                let stmt = self.stmt.prepare(self.client)?;
-                let row = self.client.query_one(stmt, &self.params)?;
-                Ok((self.mapper)((self.extractor)(&row)))
-            }
-
-            pub fn all(self) -> Result<Vec<T>, postgres::Error> {
-                self.iter()?.collect()
-            }
-
-            pub fn opt(self) -> Result<Option<T>, postgres::Error> {
-                let stmt = self.stmt.prepare(self.client)?;
-                Ok(self
-                    .client
-                    .query_opt(stmt, &self.params)?
-                    .map(|row| (self.mapper)((self.extractor)(&row))))
-            }
-
-            pub fn iter(
-                self,
-            ) -> Result<impl Iterator<Item = Result<T, postgres::Error>> + 'a, postgres::Error>
-            {
-                let stmt = self.stmt.prepare(self.client)?;
-                let it = self
-                    .client
-                    .query_raw(stmt, cornucopia_sync::private::slice_iter(&self.params))?
-                    .iterator()
-                    .map(move |res| res.map(|row| (self.mapper)((self.extractor)(&row))));
-                Ok(it)
-            }
+        impl cornucopia_sync::Borrow for SelectTranslations {
+            type Borrow<'r> = SelectTranslationsBorrowed<'r>;
         }
         pub fn authors() -> AuthorsStmt {
             AuthorsStmt(cornucopia_sync::private::Stmt::new(
@@ -409,8 +147,8 @@ FROM
             pub fn bind<'a, C: GenericClient>(
                 &'a mut self,
                 client: &'a mut C,
-            ) -> AuthorsQuery<'a, C, Authors, 0> {
-                AuthorsQuery {
+            ) -> cornucopia_sync::private::Query<'a, C, Authors, Authors, 0> {
+                cornucopia_sync::private::Query {
                     client,
                     params: [],
                     stmt: &mut self.0,
@@ -436,8 +174,8 @@ FROM
             pub fn bind<'a, C: GenericClient>(
                 &'a mut self,
                 client: &'a mut C,
-            ) -> StringQuery<'a, C, String, 0> {
-                StringQuery {
+            ) -> cornucopia_sync::private::Query<'a, C, String, String, 0> {
+                cornucopia_sync::private::Query {
                     client,
                     params: [],
                     stmt: &mut self.0,
@@ -462,8 +200,8 @@ WHERE
                 &'a mut self,
                 client: &'a mut C,
                 id: &'a i32,
-            ) -> StringQuery<'a, C, String, 1> {
-                StringQuery {
+            ) -> cornucopia_sync::private::Query<'a, C, String, String, 1> {
+                cornucopia_sync::private::Query {
                     client,
                     params: [id],
                     stmt: &mut self.0,
@@ -493,8 +231,14 @@ WHERE
                 &'a mut self,
                 client: &'a mut C,
                 start_str: &'a T1,
-            ) -> AuthorNameStartingWithQuery<'a, C, AuthorNameStartingWith, 1> {
-                AuthorNameStartingWithQuery {
+            ) -> cornucopia_sync::private::Query<
+                'a,
+                C,
+                AuthorNameStartingWith,
+                AuthorNameStartingWith,
+                1,
+            > {
+                cornucopia_sync::private::Query {
                     client,
                     params: [start_str],
                     stmt: &mut self.0,
@@ -512,7 +256,13 @@ WHERE
             cornucopia_sync::Params<
                 'a,
                 AuthorNameStartingWithParams<T1>,
-                AuthorNameStartingWithQuery<'a, C, AuthorNameStartingWith, 1>,
+                cornucopia_sync::private::Query<
+                    'a,
+                    C,
+                    AuthorNameStartingWith,
+                    AuthorNameStartingWith,
+                    1,
+                >,
                 C,
             > for AuthorNameStartingWithStmt
         {
@@ -520,7 +270,13 @@ WHERE
                 &'a mut self,
                 client: &'a mut C,
                 params: &'a AuthorNameStartingWithParams<T1>,
-            ) -> AuthorNameStartingWithQuery<'a, C, AuthorNameStartingWith, 1> {
+            ) -> cornucopia_sync::private::Query<
+                'a,
+                C,
+                AuthorNameStartingWith,
+                AuthorNameStartingWith,
+                1,
+            > {
                 self.bind(client, &params.start_str)
             }
         }
@@ -539,13 +295,14 @@ WHERE (col1).persona = $1",
                 &'a mut self,
                 client: &'a mut C,
                 spongebob_character: &'a super::super::types::public::SpongebobCharacter,
-            ) -> SuperSuperTypesPublicSpongebobCharacterQuery<
+            ) -> cornucopia_sync::private::Query<
                 'a,
                 C,
                 super::super::types::public::SpongebobCharacter,
+                super::super::types::public::SpongebobCharacter,
                 1,
             > {
-                SuperSuperTypesPublicSpongebobCharacterQuery {
+                cornucopia_sync::private::Query {
                     client,
                     params: [spongebob_character],
                     stmt: &mut self.0,
@@ -568,8 +325,9 @@ FROM
             pub fn bind<'a, C: GenericClient>(
                 &'a mut self,
                 client: &'a mut C,
-            ) -> SelectTranslationsQuery<'a, C, SelectTranslations, 0> {
-                SelectTranslationsQuery {
+            ) -> cornucopia_sync::private::Query<'a, C, SelectTranslations, SelectTranslations, 0>
+            {
+                cornucopia_sync::private::Query {
                     client,
                     params: [],
                     stmt: &mut self.0,

--- a/examples/basic_sync/src/main.rs
+++ b/examples/basic_sync/src/main.rs
@@ -1,3 +1,5 @@
+#![feature(generic_associated_types)]
+
 // Take a look at the generated `cornucopia.rs` file if you want to
 // see what it looks like under the hood.
 mod cornucopia;

--- a/integration/src/main.rs
+++ b/integration/src/main.rs
@@ -1,3 +1,5 @@
+#![feature(generic_associated_types)]
+
 use std::{
     borrow::Cow,
     fmt::Display,
@@ -245,7 +247,7 @@ fn run_codegen_test(
                     .output()?;
             } else {
                 // Get currently checked-in generate file
-                let old_codegen = std::fs::read_to_string(&destination).unwrap_or_default();
+                let old_codegen = std::fs::read_to_string(destination).unwrap_or_default();
                 // Generate new file
                 let new_codegen = cornucopia::generate_live(
                     client,


### PR DESCRIPTION
This is an experimental PR showing how the soon-to-be-stabilised[GAT](https://github.com/rust-lang/rust/pull/96709) feature can help us generate less code.