### PR TITLE
Check name conflict in generated code

### DIFF
--- a/cornucopia/src/codegen.rs
+++ b/cornucopia/src/codegen.rs
@@ -59,21 +59,6 @@ impl PreparedField {
     }
 }
 
-// Unused for now, but could be used eventually to error on reserved
-// keywords, or support them via raw identifiers.
-#[allow(unused)]
-fn is_reserved_keyword(s: &str) -> bool {
-    [
-        "as", "break", "const", "continue", "crate", "else", "enum", "extern", "false", "fn",
-        "for", "if", "impl", "in", "let", "loop", "match", "mod", "move", "mut", "pub", "ref",
-        "return", "self", "Self", "static", "struct", "super", "trait", "true", "type", "unsafe",
-        "use", "where", "while", "async", "await", "dyn", "abstract", "become", "box", "do",
-        "final", "macro", "override", "priv", "typeof", "unsized", "virtual", "yield", "try",
-        "union",
-    ]
-    .contains(&s)
-}
-
 fn struct_tosql(
     w: &mut impl Write,
     struct_name: &str,

--- a/cornucopia/src/parser.rs
+++ b/cornucopia/src/parser.rs
@@ -132,13 +132,16 @@ impl TypeAnnotation {
 }
 
 #[derive(Debug)]
-pub(crate) struct QuerySql {
-    pub(crate) span: SourceSpan,
+pub(crate) struct Query {
+    pub(crate) name: Span<String>,
+    pub(crate) param: QueryDataStruct,
+    pub(crate) row: QueryDataStruct,
+    pub(crate) sql_span: SourceSpan,
     pub(crate) sql_str: String,
     pub(crate) bind_params: Vec<Span<String>>,
 }
 
-impl QuerySql {
+impl Query {
     /// Escape sql string and pattern that are not bind
     fn sql_escaping() -> impl Parser<char, (), Error = Simple<char>> {
         // https://www.postgresql.org/docs/current/sql-syntax-lexical.html
@@ -190,7 +193,9 @@ impl QuerySql {
             .allow_trailing()
     }
 
-    fn parser() -> impl Parser<char, Self, Error = Simple<char>> {
+    /// Parse sql query, normalizing named parameters
+    fn parse_sql_query(
+    ) -> impl Parser<char, (String, SourceSpan, Vec<Span<String>>), Error = Simple<char>> {
         none_of(";")
             .repeated()
             .then_ignore(just(';'))
@@ -213,28 +218,43 @@ impl QuerySql {
                     sql_str.replace_range(start..=end, &format!("${}", index + 1));
                 }
 
-                Self {
-                    sql_str,
-                    bind_params: dedup_params,
-                    span: span.into(),
-                }
+                (sql_str, span.into(), dedup_params)
             })
     }
-}
 
-#[derive(Debug)]
-pub(crate) struct Query {
-    pub(crate) annotation: QueryAnnotation,
-    pub(crate) sql: QuerySql,
-}
+    fn parse_query_annotation(
+    ) -> impl Parser<char, (Span<String>, QueryDataStruct, QueryDataStruct), Error = Simple<char>>
+    {
+        just("--!")
+            .ignore_then(space())
+            .ignore_then(ident())
+            .then_ignore(space())
+            .then(QueryDataStruct::parser().or_not())
+            .then_ignore(space())
+            .then(
+                just(':')
+                    .ignore_then(space())
+                    .ignore_then(QueryDataStruct::parser())
+                    .or_not(),
+            )
+            .map(|((name, param), row)| (name, param.unwrap_or_default(), row.unwrap_or_default()))
+    }
 
-impl Query {
     fn parser() -> impl Parser<char, Self, Error = Simple<char>> {
-        QueryAnnotation::parser()
+        Self::parse_query_annotation()
             .then_ignore(space())
             .then_ignore(ln())
-            .then(QuerySql::parser())
-            .map(|(annotation, sql)| Self { annotation, sql })
+            .then(Self::parse_sql_query())
+            .map(
+                |((name, param, row), (sql_str, sql_span, bind_params))| Self {
+                    name,
+                    param,
+                    row,
+                    sql_span,
+                    sql_str,
+                    bind_params,
+                },
+            )
     }
 }
 
@@ -288,35 +308,6 @@ impl QueryDataStruct {
 }
 
 #[derive(Debug)]
-pub(crate) struct QueryAnnotation {
-    pub(crate) name: Span<String>,
-    pub(crate) param: QueryDataStruct,
-    pub(crate) row: QueryDataStruct,
-}
-
-impl QueryAnnotation {
-    fn parser() -> impl Parser<char, Self, Error = Simple<char>> {
-        just("--!")
-            .ignore_then(space())
-            .ignore_then(ident())
-            .then_ignore(space())
-            .then(QueryDataStruct::parser().or_not())
-            .then_ignore(space())
-            .then(
-                just(':')
-                    .ignore_then(space())
-                    .ignore_then(QueryDataStruct::parser())
-                    .or_not(),
-            )
-            .map(|((name, param), row)| Self {
-                name,
-                param: param.unwrap_or_default(),
-                row: row.unwrap_or_default(),
-            })
-    }
-}
-
-#[derive(Debug)]
 enum Statement {
     Type(TypeAnnotation),
     Query(Query),
@@ -324,39 +315,42 @@ enum Statement {
 
 #[derive(Debug)]
 pub(crate) struct Module {
+    pub(crate) info: ModuleInfo,
     pub(crate) types: Vec<TypeAnnotation>,
     pub(crate) queries: Vec<Query>,
 }
 
-impl FromIterator<Statement> for Module {
-    fn from_iter<T: IntoIterator<Item = Statement>>(iter: T) -> Self {
-        let mut types = Vec::new();
-        let mut queries = Vec::new();
-        for item in iter {
-            match item {
-                Statement::Type(it) => types.push(it),
-                Statement::Query(it) => queries.push(it),
-            }
-        }
-        Module { types, queries }
-    }
-}
-
-pub(crate) fn parse_query_module(module_info: &ModuleInfo) -> Result<Module, Error> {
-    TypeAnnotation::parser()
+pub(crate) fn parse_query_module(info: ModuleInfo) -> Result<Module, Error> {
+    match TypeAnnotation::parser()
         .map(Statement::Type)
         .or(Query::parser().map(Statement::Query))
         .separated_by(blank())
         .allow_leading()
         .allow_trailing()
         .then_ignore(end())
-        .collect()
-        .parse(module_info.content.as_str())
-        .map_err(|e| Error {
-            src: module_info.into(),
+        .parse(info.content.as_str())
+    {
+        Ok(statements) => {
+            let mut types = Vec::new();
+            let mut queries = Vec::new();
+            for item in statements {
+                match item {
+                    Statement::Type(it) => types.push(it),
+                    Statement::Query(it) => queries.push(it),
+                }
+            }
+            Ok(Module {
+                info,
+                types,
+                queries,
+            })
+        }
+        Err(e) => Err(Error {
+            src: info.into(),
             err_span: e[0].span().into(),
             help: e[0].to_string().replace('\n', "\\n"),
-        })
+        }),
+    }
 }
 
 pub(crate) mod error {

--- a/cornucopia/src/prepare_queries.rs
+++ b/cornucopia/src/prepare_queries.rs
@@ -337,6 +337,8 @@ fn prepare_query(
             .zip(stmt_params)
             .map(|(a, b)| (a.clone(), b.clone()))
             .collect::<Vec<(Span<String>, Type)>>();
+        // Check for param declaration on simple query
+        validation::param_on_simple_query(&module.info, &name, &sql_span, &param, &params)?;
         for nullable_col in nullable_params_fields {
             // If none of the row's columns match the nullable column
             validation::nullable_param_name(&module.info, nullable_col, &params)

--- a/cornucopia/src/prepare_queries.rs
+++ b/cornucopia/src/prepare_queries.rs
@@ -73,9 +73,9 @@ pub(crate) enum PreparedContent {
 #[derive(Debug, Clone)]
 pub(crate) struct PreparedModule {
     pub(crate) info: ModuleInfo,
-    pub(crate) queries: IndexMap<String, PreparedQuery>,
-    pub(crate) params: IndexMap<String, PreparedParams>,
-    pub(crate) rows: IndexMap<String, PreparedRow>,
+    pub(crate) queries: IndexMap<Span<String>, PreparedQuery>,
+    pub(crate) params: IndexMap<Span<String>, PreparedParams>,
+    pub(crate) rows: IndexMap<Span<String>, PreparedRow>,
 }
 
 #[derive(Debug, Clone)]
@@ -93,7 +93,7 @@ impl PreparedModule {
         is_implicit: bool,
     ) -> Result<(usize, Vec<usize>), Error> {
         assert!(!fields.is_empty());
-        match self.rows.entry(name.value.clone()) {
+        match self.rows.entry(name.clone()) {
             Entry::Occupied(o) => {
                 let prev = &o.get();
                 // If the row doesn't contain the same fields as a previously
@@ -134,7 +134,7 @@ impl PreparedModule {
     ) -> Result<usize, Error> {
         let fields = &self.queries.get_index(query_idx).unwrap().1.params;
         assert!(!fields.is_empty());
-        match self.params.entry(name.value.clone()) {
+        match self.params.entry(name.clone()) {
             Entry::Occupied(mut o) => {
                 let prev = o.get_mut();
                 // If the param doesn't contain the same fields as a previously
@@ -167,7 +167,7 @@ impl PreparedModule {
 
     fn add_query(
         &mut self,
-        name: String,
+        name: Span<String>,
         params: Vec<PreparedField>,
         params_is_implicit: bool,
         row_idx: Option<(usize, Vec<usize>)>,
@@ -177,7 +177,7 @@ impl PreparedModule {
             .insert_full(
                 name.clone(),
                 PreparedQuery {
-                    name,
+                    name: name.value,
                     params,
                     row: row_idx,
                     sql,
@@ -303,6 +303,8 @@ fn prepare_module(
         )?;
     }
 
+    validation::validate_preparation(&tmp_prepared_module)?;
+
     Ok(tmp_prepared_module)
 }
 
@@ -404,13 +406,7 @@ fn prepare_query(
         )?)
     };
     let params_is_implicit = matches!(params, QueryDataStruct::Implicit { .. });
-    let query_idx = module.add_query(
-        name.value.clone(),
-        params_fields,
-        params_is_implicit,
-        row_idx,
-        sql_str,
-    );
+    let query_idx = module.add_query(name, params_fields, params_is_implicit, row_idx, sql_str);
     if !params_empty {
         module.add_param(params_name, query_idx, params_is_implicit)?;
     };

--- a/cornucopia/src/validation.rs
+++ b/cornucopia/src/validation.rs
@@ -202,7 +202,6 @@ pub(crate) fn param_on_simple_query(
     Ok(())
 }
 
-
 pub(crate) fn named_struct_field(
     info: &ModuleInfo,
     name: &Span<String>,

--- a/cornucopia/src/validation.rs
+++ b/cornucopia/src/validation.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 
 use crate::{
-    parser::{NullableIdent, Query, QueryDataStruct, Span, TypeAnnotation, Module},
+    parser::{Module, NullableIdent, Query, QueryDataStruct, Span, TypeAnnotation},
     prepare_queries::{PreparedField, PreparedModule},
     read_queries::ModuleInfo,
     utils::has_duplicate,

--- a/cornucopia/src/validation.rs
+++ b/cornucopia/src/validation.rs
@@ -279,17 +279,17 @@ pub(crate) fn validate_module(
         queries,
     }: &Module,
 ) -> Result<(), Error> {
-    query_name_already_used(&info, queries)?;
-    named_type_already_used(&info, types)?;
+    query_name_already_used(info, queries)?;
+    named_type_already_used(info, types)?;
     for ty in types {
-        duplicate_nullable_ident(&info, &ty.fields)?;
+        duplicate_nullable_ident(info, &ty.fields)?;
     }
     for query in queries {
         if let QueryDataStruct::Implicit { idents } = &query.param {
-            duplicate_nullable_ident(&info, idents)?;
+            duplicate_nullable_ident(info, idents)?;
         };
         if let QueryDataStruct::Implicit { idents } = &query.row {
-            duplicate_nullable_ident(&info, idents)?;
+            duplicate_nullable_ident(info, idents)?;
         };
     }
     Ok(())

--- a/integration/fixtures/errors/codegen.toml
+++ b/integration/fixtures/errors/codegen.toml
@@ -1,0 +1,109 @@
+[[test]]
+name = 'ClashBorrowed'
+query = '''
+--! select
+SELECT * FROM author;
+
+--! select_borrowed
+SELECT * FROM author;
+'''
+error = '''
+× `SelectBorrowed` is used multiple time
+   ╭─[queries/test.sql:1:1]
+ 1 │ --! select
+   ·     ───┬──
+   ·        ╰── previous definition as borrowed row here
+ 2 │ SELECT * FROM author;
+ 3 │ 
+ 4 │ --! select_borrowed
+   ·     ───────┬───────
+   ·            ╰── redefined as row here
+ 5 │ SELECT * FROM author;
+   ╰────
+  help: use a different name for one of those'''
+
+[[test]]
+name = 'ClashParams'
+query = '''
+--! new_author
+INSERT INTO Author (id, name) VALUES (:id, :name);
+
+--! new_author_params
+SELECT * FROM author;
+'''
+error = '''
+× `NewAuthorParams` is used multiple time
+   ╭─[queries/test.sql:1:1]
+ 1 │ --! new_author
+   ·     ─────┬────
+   ·          ╰── previous definition as params here
+ 2 │ INSERT INTO Author (id, name) VALUES (:id, :name);
+ 3 │ 
+ 4 │ --! new_author_params
+   ·     ────────┬────────
+   ·             ╰── redefined as row here
+ 5 │ SELECT * FROM author;
+   ╰────
+  help: use a different name for one of those'''
+
+[[test]]
+name = 'ClashQuery'
+query = '''
+--! select
+SELECT * FROM author;
+
+--! select_query
+SELECT * FROM author;
+'''
+error = '''
+× `SelectQuery` is used multiple time
+   ╭─[queries/test.sql:1:1]
+ 1 │ --! select
+   ·     ───┬──
+   ·        ╰── previous definition as query here
+ 2 │ SELECT * FROM author;
+ 3 │ 
+ 4 │ --! select_query
+   ·     ──────┬─────
+   ·           ╰── redefined as row here
+ 5 │ SELECT * FROM author;
+   ╰────
+  help: use a different name for one of those'''
+
+[[test]]
+name = 'ClashTypeQuery'
+query = '''
+--: AuthorParams
+--! author: AuthorParams
+INSERT INTO Author (id, name) VALUES (:id, :name) RETURNING *;
+'''
+error = '''
+× `AuthorParams` is used multiple time
+   ╭─[queries/test.sql:1:1]
+ 1 │ --: AuthorParams
+ 2 │ --! author: AuthorParams
+   ·     ───┬──  ──────┬─────
+   ·        │          ╰── redefined as row here
+   ·        ╰── previous definition as params here
+ 3 │ INSERT INTO Author (id, name) VALUES (:id, :name) RETURNING *;
+   ╰────
+  help: use a different name for one of those'''
+
+[[test]]
+name = 'ClashTypeReuse'
+query = '''
+--: Author
+--! author Author: Author
+INSERT INTO Author (id, name) VALUES (:id, :name) RETURNING *;
+'''
+error = '''
+× `Author` is used multiple time
+   ╭─[queries/test.sql:1:1]
+ 1 │ --: Author
+ 2 │ --! author Author: Author
+   ·            ───┬──  ───┬──
+   ·               │       ╰── redefined as row here
+   ·               ╰── previous definition as params here
+ 3 │ INSERT INTO Author (id, name) VALUES (:id, :name) RETURNING *;
+   ╰────
+  help: use a different name for one of those'''

--- a/integration/fixtures/errors/validation.toml
+++ b/integration/fixtures/errors/validation.toml
@@ -231,3 +231,39 @@ error = '''
    ·          ╰── but query has no binding
    ╰────
   help: remove parameter declaration'''
+
+[[test]]
+name = 'QueryReserved'
+query = '''
+--! unsized
+SELECT * FROM author;
+'''
+error = '''
+× the query `delete` declare a parameter but has no binding
+   ╭─[queries/test.sql:1:1]
+ 1 │ --! delete Param
+   ·            ──┬──
+   ·              ╰── parameter declared here
+ 2 │ DELETE FROM author;
+   · ─────────┬─────────
+   ·          ╰── but query has no binding
+   ╰────
+  help: remove parameter declaration'''
+
+[[test]]
+name = 'TypeReserved'
+query = '''
+--! select: Self
+SELECT * FROM author;
+'''
+error = '''
+× the query `delete` declare a parameter but has no binding
+   ╭─[queries/test.sql:1:1]
+ 1 │ --! delete Param
+   ·            ──┬──
+   ·              ╰── parameter declared here
+ 2 │ DELETE FROM author;
+   · ─────────┬─────────
+   ·          ╰── but query has no binding
+   ╰────
+  help: remove parameter declaration'''

--- a/integration/fixtures/errors/validation.toml
+++ b/integration/fixtures/errors/validation.toml
@@ -197,7 +197,7 @@ error = '''
   help: remove row declaration'''
 
 [[test]]
-name = 'NamedExecuteRow'
+name = 'RowOnExecute'
 query = '''
 --! delete: Row
 DELETE FROM author;
@@ -213,3 +213,21 @@ error = '''
    ·          ╰── but query return nothing
    ╰────
   help: remove row declaration'''
+
+[[test]]
+name = 'ParamOnSimpleQuery'
+query = '''
+--! delete Param
+DELETE FROM author;
+'''
+error = '''
+× the query `delete` declare a parameter but has no binding
+   ╭─[queries/test.sql:1:1]
+ 1 │ --! delete Param
+   ·            ──┬──
+   ·              ╰── parameter declared here
+ 2 │ DELETE FROM author;
+   · ─────────┬─────────
+   ·          ╰── but query has no binding
+   ╰────
+  help: remove parameter declaration'''


### PR DESCRIPTION
I thought it would be difficult, but actually, with our current architecture, it was quite easy! We now catch name conflicts in the generated code before rustc, which is much better for users.