### PR TITLE
Allow cargo to choose older version of tokio

### DIFF
--- a/cornucopia_client/Cargo.toml
+++ b/cornucopia_client/Cargo.toml
@@ -18,7 +18,7 @@ deadpool = ["async", "dep:deadpool-postgres"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-tokio = { version = "1.18.2", optional = true }
+tokio = { version = "1.13.1", optional = true }
 tokio-postgres = { version = "0.7.6", optional = true }
 postgres = "0.19.3"
 async-trait = { version = "0.1.53", optional = true }


### PR DESCRIPTION
Why?
- allow cargo to choose best matching version of tokio. for example solana for some reason is forcing 1.14 version of tokio
- I choose 1.13.1 as minimum version because this is first not affected version by this: https://github.com/rustsec/advisory-db/blob/2e646db5085a9ed5e1a75c1f90ea663606338a8f/crates/tokio/RUSTSEC-2021-0124.md
