### PR TITLE
Allow double-colon casts

### DIFF
--- a/codegen_test/queries/syntax.sql
+++ b/codegen_test/queries/syntax.sql
@@ -44,6 +44,8 @@ INSERT INTO syntax ("trick:y", price) VALUES (E'this is not a \':bind_param\'', 
 INSERT INTO syntax ("trick:y", price) VALUES (e'this is ''not'' a \':bind_param\'', :price);
 --! tricky_sql9
 INSERT INTO syntax ("trick:y", price) VALUES (E'this is \'not\' a \':bind_param\'', :price);
+--! tricky_sql10
+INSERT INTO syntax ("trick:y", price) VALUES ('this is just a cast'::text, :price);
 
 --! syntax
 SELECT * FROM syntax;

--- a/codegen_test/src/cornucopia_async.rs
+++ b/codegen_test/src/cornucopia_async.rs
@@ -4470,6 +4470,22 @@ pub mod queries {
                 client.execute(stmt, &[price]).await
             }
         }
+        pub fn tricky_sql10() -> TrickySql10Stmt {
+            TrickySql10Stmt(cornucopia_client::async_::Stmt::new(
+                "INSERT INTO syntax (\"trick:y\", price) VALUES ('this is just a cast'::text, $1)",
+            ))
+        }
+        pub struct TrickySql10Stmt(cornucopia_client::async_::Stmt);
+        impl TrickySql10Stmt {
+            pub async fn bind<'a, C: GenericClient>(
+                &'a mut self,
+                client: &'a C,
+                price: &'a f64,
+            ) -> Result<u64, tokio_postgres::Error> {
+                let stmt = self.0.prepare(client).await?;
+                client.execute(stmt, &[price]).await
+            }
+        }
         pub fn syntax() -> SyntaxStmt {
             SyntaxStmt(cornucopia_client::async_::Stmt::new("SELECT * FROM syntax"))
         }

--- a/codegen_test/src/cornucopia_sync.rs
+++ b/codegen_test/src/cornucopia_sync.rs
@@ -4306,6 +4306,22 @@ pub mod queries {
                 client.execute(stmt, &[price])
             }
         }
+        pub fn tricky_sql10() -> TrickySql10Stmt {
+            TrickySql10Stmt(cornucopia_client::sync::Stmt::new(
+                "INSERT INTO syntax (\"trick:y\", price) VALUES ('this is just a cast'::text, $1)",
+            ))
+        }
+        pub struct TrickySql10Stmt(cornucopia_client::sync::Stmt);
+        impl TrickySql10Stmt {
+            pub fn bind<'a, C: GenericClient>(
+                &'a mut self,
+                client: &'a mut C,
+                price: &'a f64,
+            ) -> Result<u64, postgres::Error> {
+                let stmt = self.0.prepare(client)?;
+                client.execute(stmt, &[price])
+            }
+        }
         pub fn syntax() -> SyntaxStmt {
             SyntaxStmt(cornucopia_client::sync::Stmt::new("SELECT * FROM syntax"))
         }

--- a/cornucopia/src/parser.rs
+++ b/cornucopia/src/parser.rs
@@ -143,6 +143,8 @@ impl Query {
     fn sql_escaping() -> impl Parser<char, (), Error = Simple<char>> {
         // https://www.postgresql.org/docs/current/sql-syntax-lexical.html
 
+        // ::bind
+        let cast = just("::").ignored();
         // ":bind" TODO is this possible ?
         let constant = none_of("\"")
             .repeated()
@@ -169,6 +171,7 @@ impl Query {
             .ignored();
 
         c_style_string
+            .or(cast)
             .or(string)
             .or(constant)
             .or(dollar_quoted)


### PR DESCRIPTION
Previously, double-colon casts like `::type` would trigger an error. While this was avoidable by using the function-like `cast(value AS type)` syntax instead, it's a lot simpler to use the former.

I'm unfamiliar with `chomsky`, so it might very well be that the combinators I used are not the best for the task at hand, so please take a look at that. The idea was that a cast is always a double-colon (`"::"`) followed by an identifier, and an optional pair of square brackets (`"[]"`) to denote arrays.

Let me know if this needs anything else.