### PR TITLE
Comment public items

### DIFF
--- a/bench/Cargo.toml
+++ b/bench/Cargo.toml
@@ -13,7 +13,7 @@ postgres = "0.19.3"
 tokio-postgres = "0.7.6"
 postgres-types = "0.2.3"
 cornucopia = { path = "../cornucopia" }
-cornucopia_client = { path = "../cornucopia_client" }
+cornucopia_client = { path = "../cornucopia_client", features = ["sync"] }
 diesel = { version = "2.0.0-rc.0", features = ["postgres"] }
 
 [[bench]]

--- a/codegen_test/Cargo.toml
+++ b/codegen_test/Cargo.toml
@@ -18,7 +18,7 @@ tokio-postgres = { version = "0.7.6", features = [
     "with-uuid-1",
     "with-eui48-1",
 ] }
-cornucopia_client = { path = "../cornucopia_client" }
+cornucopia_client = { path = "../cornucopia_client", features = ["sync"] }
 postgres-types = { version = "0.2.3", features = ["derive"] }
 serde = { version = "1.0.138", features = ["derive"] }
 serde_json = { version = "1.0.82", features = ["raw_value"] }

--- a/cornucopia/src/conn.rs
+++ b/cornucopia/src/conn.rs
@@ -7,7 +7,7 @@ pub(crate) fn from_url(url: &str) -> Result<Client, Error> {
     Ok(Client::connect(url, NoTls)?)
 }
 
-/// Create a non-TLS connection for usage internal to Cornucopia.
+/// Create a non-TLS connection to the container managed by Cornucopia.
 pub fn cornucopia_conn() -> Result<Client, Error> {
     Ok(Config::new()
         .user("postgres")

--- a/cornucopia/src/error.rs
+++ b/cornucopia/src/error.rs
@@ -1,17 +1,26 @@
 use miette::{Diagnostic, GraphicalReportHandler, GraphicalTheme};
 use thiserror::Error as ThisError;
 
+/// Enumeration of all the errors reported by Cornucopia.
 #[derive(Debug, ThisError, Diagnostic)]
 #[error(transparent)]
 #[diagnostic(transparent)]
 pub enum Error {
+    /// An error while trying to connect to a database.
     Connection(#[from] crate::conn::error::Error),
+    /// An error while trying to read PostgreSQL query files.
     ReadQueries(#[from] crate::read_queries::error::Error),
+    /// An error while trying to parse PostgreSQL query files.
     ParseQueries(#[from] crate::parser::error::Error),
+    /// An error while trying to validate PostgreSQL query files.
     ValidateQueries(#[from] crate::validation::error::Error),
+    /// An error while manipulating a container managed by Cornucopia.
     Container(#[from] crate::container::error::Error),
+    /// An error while trying to prepare PostgreSQL queries.
     PrepareQueries(#[from] crate::prepare_queries::error::Error),
+    /// An error while reading PostgreSQL schema files.
     LoadSchema(#[from] crate::load_schema::error::Error),
+    /// An error while trying to write the generated code to its destination file.
     WriteCodeGenFile(#[from] WriteOutputError),
 }
 

--- a/cornucopia/src/lib.rs
+++ b/cornucopia/src/lib.rs
@@ -22,7 +22,9 @@ use parser::parse_query_module;
 use prepare_queries::prepare;
 use read_queries::read_query_modules;
 
+#[doc(hidden)]
 pub use cli::run;
+
 pub use error::Error;
 pub use load_schema::load_schema;
 

--- a/cornucopia/src/lib.rs
+++ b/cornucopia/src/lib.rs
@@ -35,8 +35,10 @@ pub struct CodegenSettings {
     pub derive_ser: bool,
 }
 
-/// Generates your cornucopia queries residing in `queries_path`.
-/// If some `destination` is given, the generated code will be written at that path.
+/// Generates Rust queries from PostgreSQL queries located at `queries_path`, 
+/// using a live database managed by you. If some `destination` is given, 
+/// the generated code will be written at that path. Code generation settings are
+/// set using the `settings` parameter.
 pub fn generate_live(
     client: &mut Client,
     queries_path: &str,
@@ -59,9 +61,13 @@ pub fn generate_live(
     Ok(generated_code)
 }
 
-/// Generates your cornucopia queries residing in `queries_path` against a container
-/// managed by cornucopia. The database is created using`schema_files`.
+/// Generates Rust queries from PostgreSQL queries located at `queries_path`, using 
+/// a container managed by cornucopia. The database schema is created using `schema_files`.
 /// If some `destination` is given, the generated code will be written at that path.
+/// Code generation settings are set using the `settings` parameter.
+/// 
+/// By default, the container manager is Docker, but Podman can be used by setting the
+/// `podman` parameter to `true`.
 pub fn generate_managed(
     queries_path: &str,
     schema_files: Vec<String>,

--- a/cornucopia/src/lib.rs
+++ b/cornucopia/src/lib.rs
@@ -9,7 +9,9 @@ mod type_registrar;
 mod utils;
 mod validation;
 
+/// Helpers to establish connections to database instances.
 pub mod conn;
+/// High-level interfaces to work with Cornucopia's container manager.
 pub mod container;
 
 use postgres::Client;
@@ -24,6 +26,7 @@ pub use cli::run;
 pub use error::Error;
 pub use load_schema::load_schema;
 
+/// Struct containing the settings for code generation.
 #[derive(Clone, Copy)]
 pub struct CodegenSettings {
     pub is_async: bool,

--- a/cornucopia/src/lib.rs
+++ b/cornucopia/src/lib.rs
@@ -35,8 +35,8 @@ pub struct CodegenSettings {
     pub derive_ser: bool,
 }
 
-/// Generates Rust queries from PostgreSQL queries located at `queries_path`, 
-/// using a live database managed by you. If some `destination` is given, 
+/// Generates Rust queries from PostgreSQL queries located at `queries_path`,
+/// using a live database managed by you. If some `destination` is given,
 /// the generated code will be written at that path. Code generation settings are
 /// set using the `settings` parameter.
 pub fn generate_live(
@@ -61,11 +61,11 @@ pub fn generate_live(
     Ok(generated_code)
 }
 
-/// Generates Rust queries from PostgreSQL queries located at `queries_path`, using 
+/// Generates Rust queries from PostgreSQL queries located at `queries_path`, using
 /// a container managed by cornucopia. The database schema is created using `schema_files`.
 /// If some `destination` is given, the generated code will be written at that path.
 /// Code generation settings are set using the `settings` parameter.
-/// 
+///
 /// By default, the container manager is Docker, but Podman can be used by setting the
 /// `podman` parameter to `true`.
 pub fn generate_managed(

--- a/cornucopia/src/load_schema.rs
+++ b/cornucopia/src/load_schema.rs
@@ -5,7 +5,9 @@ use crate::utils::db_err;
 
 use self::error::Error;
 
-/// Load schema into a database. Take a list of files paths as arguments and load them in their given order.
+/// Loads PostgreSQL schemas into a database. 
+/// 
+/// Takes a list of file paths as parameter and loads them in their given order.
 pub fn load_schema(client: &mut Client, paths: Vec<String>) -> Result<(), Error> {
     for path in paths {
         let sql = std::fs::read_to_string(&path).map_err(|err| Error::Io {

--- a/cornucopia/src/load_schema.rs
+++ b/cornucopia/src/load_schema.rs
@@ -5,8 +5,8 @@ use crate::utils::db_err;
 
 use self::error::Error;
 
-/// Loads PostgreSQL schemas into a database. 
-/// 
+/// Loads PostgreSQL schemas into a database.
+///
 /// Takes a list of file paths as parameter and loads them in their given order.
 pub fn load_schema(client: &mut Client, paths: Vec<String>) -> Result<(), Error> {
     for path in paths {

--- a/cornucopia/src/read_queries.rs
+++ b/cornucopia/src/read_queries.rs
@@ -71,7 +71,7 @@ pub(crate) fn read_query_modules(dir_path: &str) -> Result<Vec<ModuleInfo>, Erro
 pub(crate) mod error {
     use miette::Diagnostic;
     use thiserror::Error as ThisError;
-
+    
     #[derive(Debug, ThisError, Diagnostic)]
     #[error("[{path}] : {err:#}")]
     pub struct Error {

--- a/cornucopia/src/read_queries.rs
+++ b/cornucopia/src/read_queries.rs
@@ -71,7 +71,7 @@ pub(crate) fn read_query_modules(dir_path: &str) -> Result<Vec<ModuleInfo>, Erro
 pub(crate) mod error {
     use miette::Diagnostic;
     use thiserror::Error as ThisError;
-    
+
     #[derive(Debug, ThisError, Diagnostic)]
     #[error("[{path}] : {err:#}")]
     pub struct Error {

--- a/cornucopia_client/Cargo.toml
+++ b/cornucopia_client/Cargo.toml
@@ -14,12 +14,13 @@ keywords = ["postgresql", "query", "generator", "sql", "tokio-postgres"]
 default = ["deadpool"]
 async = ["dep:tokio-postgres", "dep:async-trait"]
 deadpool = ["async", "dep:deadpool-postgres"]
+sync = ["dep:postgres"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 tokio-postgres = { version = "0.7.6", optional = true }
-postgres = "0.19.3"
+postgres = { version = "0.19.3", optional = true }
 async-trait = { version = "0.1.56", optional = true }
 deadpool-postgres = { version = "0.10.2", optional = true }
 fallible-iterator = "0.2"

--- a/cornucopia_client/src/array_iterator.rs
+++ b/cornucopia_client/src/array_iterator.rs
@@ -5,7 +5,7 @@ use std::{fmt::Debug, marker::PhantomData};
 
 use crate::private::escape_domain;
 
-/// Iterator over a PostgreSQL array. You only need this if you are
+/// Iterator over the items in a PostgreSQL array. You only need this if you are
 /// working with custom zero-cost type mapping of rows containing PostgreSQL arrays.
 pub struct ArrayIterator<'a, T: FromSql<'a>> {
     values: ArrayValues<'a>,

--- a/cornucopia_client/src/array_iterator.rs
+++ b/cornucopia_client/src/array_iterator.rs
@@ -5,6 +5,8 @@ use std::{fmt::Debug, marker::PhantomData};
 
 use crate::private::escape_domain;
 
+/// Iterator over a PostgreSQL array. You only need this if you are
+/// working with custom zero-cost type mapping of rows containing PostgreSQL arrays.
 pub struct ArrayIterator<'a, T: FromSql<'a>> {
     values: ArrayValues<'a>,
     ty: Type,

--- a/cornucopia_client/src/async_.rs
+++ b/cornucopia_client/src/async_.rs
@@ -3,6 +3,11 @@ use tokio_postgres::{
     types::BorrowToSql, Client, Error, RowStream, Statement, ToStatement, Transaction,
 };
 
+/// Abstraction over multiple types of asynchronous clients.
+/// This allows you to use tokio_postgres clients and transactions interchangeably.
+///
+/// In addition, when the `deadpool` feature is enabled (default), this trait also
+/// abstracts over deadpool clients and transactions
 #[async_trait]
 pub trait GenericClient {
     async fn prepare(&self, query: &str) -> Result<Statement, Error>;

--- a/cornucopia_client/src/lib.rs
+++ b/cornucopia_client/src/lib.rs
@@ -1,45 +1,21 @@
 mod array_iterator;
+
 #[cfg(feature = "async")]
+#[doc(hidden)]
 pub mod async_;
+
 #[cfg(feature = "deadpool")]
+#[doc(hidden)]
 mod deadpool;
+
+#[cfg(feature = "sync")]
+#[doc(hidden)]
+pub mod sync;
+
 #[doc(hidden)]
 pub mod private;
 
 pub use array_iterator::ArrayIterator;
 
-pub mod sync {
-    use postgres::Statement;
-
-    /// Cached statement
-    pub struct Stmt {
-        query: &'static str,
-        cached: Option<Statement>,
-    }
-
-    impl Stmt {
-        #[must_use]
-        pub fn new(query: &'static str) -> Self {
-            Self {
-                query,
-                cached: None,
-            }
-        }
-
-        pub fn prepare<'a, C: postgres::GenericClient>(
-            &'a mut self,
-            client: &mut C,
-        ) -> Result<&'a Statement, postgres::Error> {
-            if self.cached.is_none() {
-                let stmt = client.prepare(self.query)?;
-                self.cached = Some(stmt);
-            }
-            // the statement is always prepared at this point
-            Ok(unsafe { self.cached.as_ref().unwrap_unchecked() })
-        }
-    }
-
-    pub trait Params<'a, S, O, C> {
-        fn bind(&'a self, client: &'a mut C, stmt: &'a mut S) -> O;
-    }
-}
+#[cfg(feature = "async")]
+pub use async_::GenericClient;

--- a/cornucopia_client/src/sync.rs
+++ b/cornucopia_client/src/sync.rs
@@ -1,0 +1,33 @@
+use postgres::Statement;
+
+/// Cached statement
+pub struct Stmt {
+    query: &'static str,
+    cached: Option<Statement>,
+}
+
+impl Stmt {
+    #[must_use]
+    pub fn new(query: &'static str) -> Self {
+        Self {
+            query,
+            cached: None,
+        }
+    }
+
+    pub fn prepare<'a, C: postgres::GenericClient>(
+        &'a mut self,
+        client: &mut C,
+    ) -> Result<&'a Statement, postgres::Error> {
+        if self.cached.is_none() {
+            let stmt = client.prepare(self.query)?;
+            self.cached = Some(stmt);
+        }
+        // the statement is always prepared at this point
+        Ok(unsafe { self.cached.as_ref().unwrap_unchecked() })
+    }
+}
+
+pub trait Params<'a, S, O, C> {
+    fn bind(&'a self, client: &'a mut C, stmt: &'a mut S) -> O;
+}

--- a/examples/basic_sync/Cargo.toml
+++ b/examples/basic_sync/Cargo.toml
@@ -8,4 +8,6 @@ edition = "2021"
 [dependencies]
 postgres-types = { version = "0.2.3", features = ["derive"] }
 postgres = "0.19.3"
-cornucopia_client = { path = "../../cornucopia_client", default-features = false }
+cornucopia_client = { path = "../../cornucopia_client", default-features = false, features = [
+    "sync",
+] }


### PR DESCRIPTION
Closes #122.

This PR adds routine documentation comments to our public items. I've taken the liberty to feature-gate and/or use `#[docs(hidden)]` where it seemed appropriate, to keep our API docs super slim.

I still have to review a couple of pre-existing doc comments, but most of the work should be there.