### PR TITLE
Better codegen and async fix

### DIFF
--- a/bench/usage/cornucopia_benches/generated_async.rs
+++ b/bench/usage/cornucopia_benches/generated_async.rs
@@ -399,12 +399,16 @@ pub mod queries {
                 client.execute(stmt, &[name, hair_color]).await
             }
         }
-        impl<'a, C: GenericClient>
+        impl<'a, C: GenericClient + Send + Sync>
             cornucopia_client::async_::Params<
                 'a,
                 InsertUserParams<'a>,
                 std::pin::Pin<
-                    Box<dyn futures::Future<Output = Result<u64, tokio_postgres::Error>> + 'a>,
+                    Box<
+                        dyn futures::Future<Output = Result<u64, tokio_postgres::Error>>
+                            + Send
+                            + 'a,
+                    >,
                 >,
                 C,
             > for InsertUserStmt
@@ -414,7 +418,7 @@ pub mod queries {
                 client: &'a C,
                 params: &'a InsertUserParams<'a>,
             ) -> std::pin::Pin<
-                Box<dyn futures::Future<Output = Result<u64, tokio_postgres::Error>> + 'a>,
+                Box<dyn futures::Future<Output = Result<u64, tokio_postgres::Error>> + Send + 'a>,
             > {
                 Box::pin(self.bind(client, &params.name, &params.hair_color))
             }

--- a/bench/usage/cornucopia_benches/generated_async.rs
+++ b/bench/usage/cornucopia_benches/generated_async.rs
@@ -398,41 +398,28 @@ pub mod queries {
                 let stmt = self.0.prepare(client).await?;
                 client.execute(stmt, &[name, hair_color]).await
             }
-            pub async fn params<'a, C: GenericClient>(
-                &'a mut self,
-                client: &'a C,
-                params: &'a impl cornucopia_client::async_::Params<
-                    'a,
-                    Self,
-                    std::pin::Pin<
-                        Box<dyn futures::Future<Output = Result<u64, tokio_postgres::Error>>>,
-                    >,
-                    C,
-                >,
-            ) -> Result<u64, tokio_postgres::Error> {
-                params.bind(client, self).await
-            }
         }
         impl<'a, C: GenericClient>
             cornucopia_client::async_::Params<
                 'a,
-                InsertUserStmt,
+                InsertUserParams<'a>,
                 std::pin::Pin<
                     Box<dyn futures::Future<Output = Result<u64, tokio_postgres::Error>> + 'a>,
                 >,
                 C,
-            > for InsertUserParams<'a>
+            > for InsertUserStmt
         {
-            fn bind(
-                &'a self,
+            fn params(
+                &'a mut self,
                 client: &'a C,
-                stmt: &'a mut InsertUserStmt,
+                params: &'a InsertUserParams<'a>,
             ) -> std::pin::Pin<
                 Box<dyn futures::Future<Output = Result<u64, tokio_postgres::Error>> + 'a>,
             > {
-                Box::pin(stmt.bind(client, &self.name, &self.hair_color))
+                Box::pin(self.bind(client, &params.name, &params.hair_color))
             }
         }
+
         pub fn posts() -> PostsStmt {
             PostsStmt(cornucopia_client::async_::Stmt::new("SELECT * FROM posts"))
         }

--- a/bench/usage/cornucopia_benches/generated_sync.rs
+++ b/bench/usage/cornucopia_benches/generated_sync.rs
@@ -380,31 +380,24 @@ pub mod queries {
                 let stmt = self.0.prepare(client)?;
                 client.execute(stmt, &[name, hair_color])
             }
-            pub fn params<'a, C: GenericClient>(
-                &'a mut self,
-                client: &'a mut C,
-                params: &'a impl cornucopia_client::sync::Params<
-                    'a,
-                    Self,
-                    Result<u64, postgres::Error>,
-                    C,
-                >,
-            ) -> Result<u64, postgres::Error> {
-                params.bind(client, self)
-            }
         }
         impl<'a, C: GenericClient>
-            cornucopia_client::sync::Params<'a, InsertUserStmt, Result<u64, postgres::Error>, C>
-            for InsertUserParams<'a>
+            cornucopia_client::sync::Params<
+                'a,
+                InsertUserParams<'a>,
+                Result<u64, postgres::Error>,
+                C,
+            > for InsertUserStmt
         {
-            fn bind(
-                &'a self,
+            fn params(
+                &'a mut self,
                 client: &'a mut C,
-                stmt: &'a mut InsertUserStmt,
+                params: &'a InsertUserParams<'a>,
             ) -> Result<u64, postgres::Error> {
-                stmt.bind(client, &self.name, &self.hair_color)
+                self.bind(client, &params.name, &params.hair_color)
             }
         }
+
         pub fn posts() -> PostsStmt {
             PostsStmt(cornucopia_client::sync::Stmt::new("SELECT * FROM posts"))
         }

--- a/codegen_test/src/cornucopia_async.rs
+++ b/codegen_test/src/cornucopia_async.rs
@@ -1304,12 +1304,16 @@ pub mod queries {
                     .await
             }
         }
-        impl<'a, C: GenericClient>
+        impl<'a, C: GenericClient + Send + Sync>
             cornucopia_client::async_::Params<
                 'a,
                 InsertNightmareDomainParams<'a>,
                 std::pin::Pin<
-                    Box<dyn futures::Future<Output = Result<u64, tokio_postgres::Error>> + 'a>,
+                    Box<
+                        dyn futures::Future<Output = Result<u64, tokio_postgres::Error>>
+                            + Send
+                            + 'a,
+                    >,
                 >,
                 C,
             > for InsertNightmareDomainStmt
@@ -1319,7 +1323,7 @@ pub mod queries {
                 client: &'a C,
                 params: &'a InsertNightmareDomainParams<'a>,
             ) -> std::pin::Pin<
-                Box<dyn futures::Future<Output = Result<u64, tokio_postgres::Error>> + 'a>,
+                Box<dyn futures::Future<Output = Result<u64, tokio_postgres::Error>> + Send + 'a>,
             > {
                 Box::pin(self.bind(
                     client,
@@ -1713,12 +1717,16 @@ pub mod queries {
                 client.execute(stmt, &[named]).await
             }
         }
-        impl<'a, C: GenericClient>
+        impl<'a, C: GenericClient + Send + Sync>
             cornucopia_client::async_::Params<
                 'a,
                 NamedComplexParams<'a>,
                 std::pin::Pin<
-                    Box<dyn futures::Future<Output = Result<u64, tokio_postgres::Error>> + 'a>,
+                    Box<
+                        dyn futures::Future<Output = Result<u64, tokio_postgres::Error>>
+                            + Send
+                            + 'a,
+                    >,
                 >,
                 C,
             > for NewNamedComplexStmt
@@ -1728,7 +1736,7 @@ pub mod queries {
                 client: &'a C,
                 params: &'a NamedComplexParams<'a>,
             ) -> std::pin::Pin<
-                Box<dyn futures::Future<Output = Result<u64, tokio_postgres::Error>> + 'a>,
+                Box<dyn futures::Future<Output = Result<u64, tokio_postgres::Error>> + Send + 'a>,
             > {
                 Box::pin(self.bind(client, &params.named))
             }
@@ -1870,12 +1878,16 @@ pub mod queries {
                 client.execute(stmt, &[texts, name, composite]).await
             }
         }
-        impl<'a, C: GenericClient>
+        impl<'a, C: GenericClient + Send + Sync>
             cornucopia_client::async_::Params<
                 'a,
                 NullityParams<'a>,
                 std::pin::Pin<
-                    Box<dyn futures::Future<Output = Result<u64, tokio_postgres::Error>> + 'a>,
+                    Box<
+                        dyn futures::Future<Output = Result<u64, tokio_postgres::Error>>
+                            + Send
+                            + 'a,
+                    >,
                 >,
                 C,
             > for NewNullityStmt
@@ -1885,7 +1897,7 @@ pub mod queries {
                 client: &'a C,
                 params: &'a NullityParams<'a>,
             ) -> std::pin::Pin<
-                Box<dyn futures::Future<Output = Result<u64, tokio_postgres::Error>> + 'a>,
+                Box<dyn futures::Future<Output = Result<u64, tokio_postgres::Error>> + Send + 'a>,
             > {
                 Box::pin(self.bind(client, &params.texts, &params.name, &params.composite))
             }
@@ -2024,12 +2036,16 @@ pub mod queries {
                 client.execute(stmt, &[author, name]).await
             }
         }
-        impl<'a, C: GenericClient>
+        impl<'a, C: GenericClient + Send + Sync>
             cornucopia_client::async_::Params<
                 'a,
                 InsertBookParams<'a>,
                 std::pin::Pin<
-                    Box<dyn futures::Future<Output = Result<u64, tokio_postgres::Error>> + 'a>,
+                    Box<
+                        dyn futures::Future<Output = Result<u64, tokio_postgres::Error>>
+                            + Send
+                            + 'a,
+                    >,
                 >,
                 C,
             > for InsertBookStmt
@@ -2039,7 +2055,7 @@ pub mod queries {
                 client: &'a C,
                 params: &'a InsertBookParams<'a>,
             ) -> std::pin::Pin<
-                Box<dyn futures::Future<Output = Result<u64, tokio_postgres::Error>> + 'a>,
+                Box<dyn futures::Future<Output = Result<u64, tokio_postgres::Error>> + Send + 'a>,
             > {
                 Box::pin(self.bind(client, &params.author, &params.name))
             }
@@ -2099,12 +2115,16 @@ pub mod queries {
                 client.execute(stmt, &[c, a]).await
             }
         }
-        impl<'a, C: GenericClient>
+        impl<'a, C: GenericClient + Send + Sync>
             cornucopia_client::async_::Params<
                 'a,
                 ParamsOrderParams,
                 std::pin::Pin<
-                    Box<dyn futures::Future<Output = Result<u64, tokio_postgres::Error>> + 'a>,
+                    Box<
+                        dyn futures::Future<Output = Result<u64, tokio_postgres::Error>>
+                            + Send
+                            + 'a,
+                    >,
                 >,
                 C,
             > for ParamsOrderStmt
@@ -2114,7 +2134,7 @@ pub mod queries {
                 client: &'a C,
                 params: &'a ParamsOrderParams,
             ) -> std::pin::Pin<
-                Box<dyn futures::Future<Output = Result<u64, tokio_postgres::Error>> + 'a>,
+                Box<dyn futures::Future<Output = Result<u64, tokio_postgres::Error>> + Send + 'a>,
             > {
                 Box::pin(self.bind(client, &params.c, &params.a))
             }
@@ -3254,12 +3274,16 @@ pub mod queries {
                     .await
             }
         }
-        impl<'a, C: GenericClient>
+        impl<'a, C: GenericClient + Send + Sync>
             cornucopia_client::async_::Params<
                 'a,
                 EverythingParams<'a>,
                 std::pin::Pin<
-                    Box<dyn futures::Future<Output = Result<u64, tokio_postgres::Error>> + 'a>,
+                    Box<
+                        dyn futures::Future<Output = Result<u64, tokio_postgres::Error>>
+                            + Send
+                            + 'a,
+                    >,
                 >,
                 C,
             > for InsertEverythingStmt
@@ -3269,7 +3293,7 @@ pub mod queries {
                 client: &'a C,
                 params: &'a EverythingParams<'a>,
             ) -> std::pin::Pin<
-                Box<dyn futures::Future<Output = Result<u64, tokio_postgres::Error>> + 'a>,
+                Box<dyn futures::Future<Output = Result<u64, tokio_postgres::Error>> + Send + 'a>,
             > {
                 Box::pin(self.bind(
                     client,
@@ -3480,12 +3504,16 @@ pub mod queries {
                     .await
             }
         }
-        impl<'a, C: GenericClient>
+        impl<'a, C: GenericClient + Send + Sync>
             cornucopia_client::async_::Params<
                 'a,
                 EverythingArrayParams<'a>,
                 std::pin::Pin<
-                    Box<dyn futures::Future<Output = Result<u64, tokio_postgres::Error>> + 'a>,
+                    Box<
+                        dyn futures::Future<Output = Result<u64, tokio_postgres::Error>>
+                            + Send
+                            + 'a,
+                    >,
                 >,
                 C,
             > for InsertEverythingArrayStmt
@@ -3495,7 +3523,7 @@ pub mod queries {
                 client: &'a C,
                 params: &'a EverythingArrayParams<'a>,
             ) -> std::pin::Pin<
-                Box<dyn futures::Future<Output = Result<u64, tokio_postgres::Error>> + 'a>,
+                Box<dyn futures::Future<Output = Result<u64, tokio_postgres::Error>> + Send + 'a>,
             > {
                 Box::pin(self.bind(
                     client,

--- a/codegen_test/src/cornucopia_async.rs
+++ b/codegen_test/src/cornucopia_async.rs
@@ -1303,48 +1303,35 @@ pub mod queries {
                     )
                     .await
             }
-            pub async fn params<'a, C: GenericClient>(
-                &'a mut self,
-                client: &'a C,
-                params: &'a impl cornucopia_client::async_::Params<
-                    'a,
-                    Self,
-                    std::pin::Pin<
-                        Box<dyn futures::Future<Output = Result<u64, tokio_postgres::Error>>>,
-                    >,
-                    C,
-                >,
-            ) -> Result<u64, tokio_postgres::Error> {
-                params.bind(client, self).await
-            }
         }
         impl<'a, C: GenericClient>
             cornucopia_client::async_::Params<
                 'a,
-                InsertNightmareDomainStmt,
+                InsertNightmareDomainParams<'a>,
                 std::pin::Pin<
                     Box<dyn futures::Future<Output = Result<u64, tokio_postgres::Error>> + 'a>,
                 >,
                 C,
-            > for InsertNightmareDomainParams<'a>
+            > for InsertNightmareDomainStmt
         {
-            fn bind(
-                &'a self,
+            fn params(
+                &'a mut self,
                 client: &'a C,
-                stmt: &'a mut InsertNightmareDomainStmt,
+                params: &'a InsertNightmareDomainParams<'a>,
             ) -> std::pin::Pin<
                 Box<dyn futures::Future<Output = Result<u64, tokio_postgres::Error>> + 'a>,
             > {
-                Box::pin(stmt.bind(
+                Box::pin(self.bind(
                     client,
-                    &self.txt,
-                    &self.json,
-                    &self.nb,
-                    &self.arr,
-                    &self.composite,
+                    &params.txt,
+                    &params.json,
+                    &params.nb,
+                    &params.arr,
+                    &params.composite,
                 ))
             }
         }
+
         pub fn select_nightmare_domain_null() -> SelectNightmareDomainNullStmt {
             SelectNightmareDomainNullStmt(cornucopia_client::async_::Stmt::new(
                 "SELECT * FROM nightmare_domain",
@@ -1614,24 +1601,17 @@ pub mod queries {
                     mapper: |it| <Id>::from(it),
                 }
             }
-            pub fn params<'a, C: GenericClient>(
-                &'a mut self,
-                client: &'a C,
-                params: &'a impl cornucopia_client::async_::Params<'a, Self, IdQuery<'a, C, Id, 2>, C>,
-            ) -> IdQuery<'a, C, Id, 2> {
-                params.bind(client, self)
-            }
         }
         impl<'a, C: GenericClient>
-            cornucopia_client::async_::Params<'a, NewNamedVisibleStmt, IdQuery<'a, C, Id, 2>, C>
-            for NamedParams<'a>
+            cornucopia_client::async_::Params<'a, NamedParams<'a>, IdQuery<'a, C, Id, 2>, C>
+            for NewNamedVisibleStmt
         {
-            fn bind(
-                &'a self,
+            fn params(
+                &'a mut self,
                 client: &'a C,
-                stmt: &'a mut NewNamedVisibleStmt,
+                params: &'a NamedParams<'a>,
             ) -> IdQuery<'a, C, Id, 2> {
-                stmt.bind(client, &self.name, &self.price)
+                self.bind(client, &params.name, &params.price)
             }
         }
         pub fn new_named_hidden() -> NewNamedHiddenStmt {
@@ -1655,24 +1635,17 @@ pub mod queries {
                     mapper: |it| <Id>::from(it),
                 }
             }
-            pub fn params<'a, C: GenericClient>(
-                &'a mut self,
-                client: &'a C,
-                params: &'a impl cornucopia_client::async_::Params<'a, Self, IdQuery<'a, C, Id, 2>, C>,
-            ) -> IdQuery<'a, C, Id, 2> {
-                params.bind(client, self)
-            }
         }
         impl<'a, C: GenericClient>
-            cornucopia_client::async_::Params<'a, NewNamedHiddenStmt, IdQuery<'a, C, Id, 2>, C>
-            for NamedParams<'a>
+            cornucopia_client::async_::Params<'a, NamedParams<'a>, IdQuery<'a, C, Id, 2>, C>
+            for NewNamedHiddenStmt
         {
-            fn bind(
-                &'a self,
+            fn params(
+                &'a mut self,
                 client: &'a C,
-                stmt: &'a mut NewNamedHiddenStmt,
+                params: &'a NamedParams<'a>,
             ) -> IdQuery<'a, C, Id, 2> {
-                stmt.bind(client, &self.price, &self.name)
+                self.bind(client, &params.price, &params.name)
             }
         }
         pub fn named() -> NamedStmt {
@@ -1739,41 +1712,28 @@ pub mod queries {
                 let stmt = self.0.prepare(client).await?;
                 client.execute(stmt, &[named]).await
             }
-            pub async fn params<'a, C: GenericClient>(
-                &'a mut self,
-                client: &'a C,
-                params: &'a impl cornucopia_client::async_::Params<
-                    'a,
-                    Self,
-                    std::pin::Pin<
-                        Box<dyn futures::Future<Output = Result<u64, tokio_postgres::Error>>>,
-                    >,
-                    C,
-                >,
-            ) -> Result<u64, tokio_postgres::Error> {
-                params.bind(client, self).await
-            }
         }
         impl<'a, C: GenericClient>
             cornucopia_client::async_::Params<
                 'a,
-                NewNamedComplexStmt,
+                NamedComplexParams<'a>,
                 std::pin::Pin<
                     Box<dyn futures::Future<Output = Result<u64, tokio_postgres::Error>> + 'a>,
                 >,
                 C,
-            > for NamedComplexParams<'a>
+            > for NewNamedComplexStmt
         {
-            fn bind(
-                &'a self,
+            fn params(
+                &'a mut self,
                 client: &'a C,
-                stmt: &'a mut NewNamedComplexStmt,
+                params: &'a NamedComplexParams<'a>,
             ) -> std::pin::Pin<
                 Box<dyn futures::Future<Output = Result<u64, tokio_postgres::Error>> + 'a>,
             > {
-                Box::pin(stmt.bind(client, &self.named))
+                Box::pin(self.bind(client, &params.named))
             }
         }
+
         pub fn named_complex() -> NamedComplexStmt {
             NamedComplexStmt(cornucopia_client::async_::Stmt::new(
                 "SELECT * FROM named_complex",
@@ -1909,41 +1869,28 @@ pub mod queries {
                 let stmt = self.0.prepare(client).await?;
                 client.execute(stmt, &[texts, name, composite]).await
             }
-            pub async fn params<'a, C: GenericClient>(
-                &'a mut self,
-                client: &'a C,
-                params: &'a impl cornucopia_client::async_::Params<
-                    'a,
-                    Self,
-                    std::pin::Pin<
-                        Box<dyn futures::Future<Output = Result<u64, tokio_postgres::Error>>>,
-                    >,
-                    C,
-                >,
-            ) -> Result<u64, tokio_postgres::Error> {
-                params.bind(client, self).await
-            }
         }
         impl<'a, C: GenericClient>
             cornucopia_client::async_::Params<
                 'a,
-                NewNullityStmt,
+                NullityParams<'a>,
                 std::pin::Pin<
                     Box<dyn futures::Future<Output = Result<u64, tokio_postgres::Error>> + 'a>,
                 >,
                 C,
-            > for NullityParams<'a>
+            > for NewNullityStmt
         {
-            fn bind(
-                &'a self,
+            fn params(
+                &'a mut self,
                 client: &'a C,
-                stmt: &'a mut NewNullityStmt,
+                params: &'a NullityParams<'a>,
             ) -> std::pin::Pin<
                 Box<dyn futures::Future<Output = Result<u64, tokio_postgres::Error>> + 'a>,
             > {
-                Box::pin(stmt.bind(client, &self.texts, &self.name, &self.composite))
+                Box::pin(self.bind(client, &params.texts, &params.name, &params.composite))
             }
         }
+
         pub fn nullity() -> NullityStmt {
             NullityStmt(cornucopia_client::async_::Stmt::new(
                 "SELECT * FROM nullity",
@@ -2076,41 +2023,28 @@ pub mod queries {
                 let stmt = self.0.prepare(client).await?;
                 client.execute(stmt, &[author, name]).await
             }
-            pub async fn params<'a, C: GenericClient>(
-                &'a mut self,
-                client: &'a C,
-                params: &'a impl cornucopia_client::async_::Params<
-                    'a,
-                    Self,
-                    std::pin::Pin<
-                        Box<dyn futures::Future<Output = Result<u64, tokio_postgres::Error>>>,
-                    >,
-                    C,
-                >,
-            ) -> Result<u64, tokio_postgres::Error> {
-                params.bind(client, self).await
-            }
         }
         impl<'a, C: GenericClient>
             cornucopia_client::async_::Params<
                 'a,
-                InsertBookStmt,
+                InsertBookParams<'a>,
                 std::pin::Pin<
                     Box<dyn futures::Future<Output = Result<u64, tokio_postgres::Error>> + 'a>,
                 >,
                 C,
-            > for InsertBookParams<'a>
+            > for InsertBookStmt
         {
-            fn bind(
-                &'a self,
+            fn params(
+                &'a mut self,
                 client: &'a C,
-                stmt: &'a mut InsertBookStmt,
+                params: &'a InsertBookParams<'a>,
             ) -> std::pin::Pin<
                 Box<dyn futures::Future<Output = Result<u64, tokio_postgres::Error>> + 'a>,
             > {
-                Box::pin(stmt.bind(client, &self.author, &self.name))
+                Box::pin(self.bind(client, &params.author, &params.name))
             }
         }
+
         pub fn select_book() -> SelectBookStmt {
             SelectBookStmt(cornucopia_client::async_::Stmt::new("SELECT * FROM book"))
         }
@@ -2164,39 +2098,25 @@ pub mod queries {
                 let stmt = self.0.prepare(client).await?;
                 client.execute(stmt, &[c, a]).await
             }
-            pub async fn params<'a, C: GenericClient>(
-                &'a mut self,
-                client: &'a C,
-                params: &'a impl cornucopia_client::async_::Params<
-                    'a,
-                    Self,
-                    std::pin::Pin<
-                        Box<dyn futures::Future<Output = Result<u64, tokio_postgres::Error>>>,
-                    >,
-                    C,
-                >,
-            ) -> Result<u64, tokio_postgres::Error> {
-                params.bind(client, self).await
-            }
         }
         impl<'a, C: GenericClient>
             cornucopia_client::async_::Params<
                 'a,
-                ParamsOrderStmt,
+                ParamsOrderParams,
                 std::pin::Pin<
                     Box<dyn futures::Future<Output = Result<u64, tokio_postgres::Error>> + 'a>,
                 >,
                 C,
-            > for ParamsOrderParams
+            > for ParamsOrderStmt
         {
-            fn bind(
-                &'a self,
+            fn params(
+                &'a mut self,
                 client: &'a C,
-                stmt: &'a mut ParamsOrderStmt,
+                params: &'a ParamsOrderParams,
             ) -> std::pin::Pin<
                 Box<dyn futures::Future<Output = Result<u64, tokio_postgres::Error>> + 'a>,
             > {
-                Box::pin(stmt.bind(client, &self.c, &self.a))
+                Box::pin(self.bind(client, &params.c, &params.a))
             }
         }
     }
@@ -3333,76 +3253,63 @@ pub mod queries {
                     )
                     .await
             }
-            pub async fn params<'a, C: GenericClient>(
-                &'a mut self,
-                client: &'a C,
-                params: &'a impl cornucopia_client::async_::Params<
-                    'a,
-                    Self,
-                    std::pin::Pin<
-                        Box<dyn futures::Future<Output = Result<u64, tokio_postgres::Error>>>,
-                    >,
-                    C,
-                >,
-            ) -> Result<u64, tokio_postgres::Error> {
-                params.bind(client, self).await
-            }
         }
         impl<'a, C: GenericClient>
             cornucopia_client::async_::Params<
                 'a,
-                InsertEverythingStmt,
+                EverythingParams<'a>,
                 std::pin::Pin<
                     Box<dyn futures::Future<Output = Result<u64, tokio_postgres::Error>> + 'a>,
                 >,
                 C,
-            > for EverythingParams<'a>
+            > for InsertEverythingStmt
         {
-            fn bind(
-                &'a self,
+            fn params(
+                &'a mut self,
                 client: &'a C,
-                stmt: &'a mut InsertEverythingStmt,
+                params: &'a EverythingParams<'a>,
             ) -> std::pin::Pin<
                 Box<dyn futures::Future<Output = Result<u64, tokio_postgres::Error>> + 'a>,
             > {
-                Box::pin(stmt.bind(
+                Box::pin(self.bind(
                     client,
-                    &self.bool_,
-                    &self.boolean_,
-                    &self.char_,
-                    &self.smallint_,
-                    &self.int2_,
-                    &self.smallserial_,
-                    &self.serial2_,
-                    &self.int_,
-                    &self.int4_,
-                    &self.serial_,
-                    &self.serial4_,
-                    &self.bingint_,
-                    &self.int8_,
-                    &self.bigserial_,
-                    &self.serial8_,
-                    &self.float4_,
-                    &self.real_,
-                    &self.float8_,
-                    &self.double_precision_,
-                    &self.text_,
-                    &self.varchar_,
-                    &self.bytea_,
-                    &self.timestamp_,
-                    &self.timestamp_without_time_zone_,
-                    &self.timestamptz_,
-                    &self.timestamp_with_time_zone_,
-                    &self.date_,
-                    &self.time_,
-                    &self.json_,
-                    &self.jsonb_,
-                    &self.uuid_,
-                    &self.inet_,
-                    &self.macaddr_,
+                    &params.bool_,
+                    &params.boolean_,
+                    &params.char_,
+                    &params.smallint_,
+                    &params.int2_,
+                    &params.smallserial_,
+                    &params.serial2_,
+                    &params.int_,
+                    &params.int4_,
+                    &params.serial_,
+                    &params.serial4_,
+                    &params.bingint_,
+                    &params.int8_,
+                    &params.bigserial_,
+                    &params.serial8_,
+                    &params.float4_,
+                    &params.real_,
+                    &params.float8_,
+                    &params.double_precision_,
+                    &params.text_,
+                    &params.varchar_,
+                    &params.bytea_,
+                    &params.timestamp_,
+                    &params.timestamp_without_time_zone_,
+                    &params.timestamptz_,
+                    &params.timestamp_with_time_zone_,
+                    &params.date_,
+                    &params.time_,
+                    &params.json_,
+                    &params.jsonb_,
+                    &params.uuid_,
+                    &params.inet_,
+                    &params.macaddr_,
                 ))
             }
         }
+
         pub fn select_everything_array() -> SelectEverythingArrayStmt {
             SelectEverythingArrayStmt(cornucopia_client::async_::Stmt::new(
                 "SELECT * FROM EverythingArray",
@@ -3572,70 +3479,57 @@ pub mod queries {
                     )
                     .await
             }
-            pub async fn params<'a, C: GenericClient>(
-                &'a mut self,
-                client: &'a C,
-                params: &'a impl cornucopia_client::async_::Params<
-                    'a,
-                    Self,
-                    std::pin::Pin<
-                        Box<dyn futures::Future<Output = Result<u64, tokio_postgres::Error>>>,
-                    >,
-                    C,
-                >,
-            ) -> Result<u64, tokio_postgres::Error> {
-                params.bind(client, self).await
-            }
         }
         impl<'a, C: GenericClient>
             cornucopia_client::async_::Params<
                 'a,
-                InsertEverythingArrayStmt,
+                EverythingArrayParams<'a>,
                 std::pin::Pin<
                     Box<dyn futures::Future<Output = Result<u64, tokio_postgres::Error>> + 'a>,
                 >,
                 C,
-            > for EverythingArrayParams<'a>
+            > for InsertEverythingArrayStmt
         {
-            fn bind(
-                &'a self,
+            fn params(
+                &'a mut self,
                 client: &'a C,
-                stmt: &'a mut InsertEverythingArrayStmt,
+                params: &'a EverythingArrayParams<'a>,
             ) -> std::pin::Pin<
                 Box<dyn futures::Future<Output = Result<u64, tokio_postgres::Error>> + 'a>,
             > {
-                Box::pin(stmt.bind(
+                Box::pin(self.bind(
                     client,
-                    &self.bool_,
-                    &self.boolean_,
-                    &self.char_,
-                    &self.smallint_,
-                    &self.int2_,
-                    &self.int_,
-                    &self.int4_,
-                    &self.bingint_,
-                    &self.int8_,
-                    &self.float4_,
-                    &self.real_,
-                    &self.float8_,
-                    &self.double_precision_,
-                    &self.text_,
-                    &self.varchar_,
-                    &self.bytea_,
-                    &self.timestamp_,
-                    &self.timestamp_without_time_zone_,
-                    &self.timestamptz_,
-                    &self.timestamp_with_time_zone_,
-                    &self.date_,
-                    &self.time_,
-                    &self.json_,
-                    &self.jsonb_,
-                    &self.uuid_,
-                    &self.inet_,
-                    &self.macaddr_,
+                    &params.bool_,
+                    &params.boolean_,
+                    &params.char_,
+                    &params.smallint_,
+                    &params.int2_,
+                    &params.int_,
+                    &params.int4_,
+                    &params.bingint_,
+                    &params.int8_,
+                    &params.float4_,
+                    &params.real_,
+                    &params.float8_,
+                    &params.double_precision_,
+                    &params.text_,
+                    &params.varchar_,
+                    &params.bytea_,
+                    &params.timestamp_,
+                    &params.timestamp_without_time_zone_,
+                    &params.timestamptz_,
+                    &params.timestamp_with_time_zone_,
+                    &params.date_,
+                    &params.time_,
+                    &params.json_,
+                    &params.jsonb_,
+                    &params.uuid_,
+                    &params.inet_,
+                    &params.macaddr_,
                 ))
             }
         }
+
         pub fn select_nightmare() -> SelectNightmareStmt {
             SelectNightmareStmt(cornucopia_client::async_::Stmt::new(
                 "SELECT * FROM nightmare",
@@ -4082,33 +3976,21 @@ pub mod queries {
                     mapper: |it| it,
                 }
             }
-            pub fn params<'a, C: GenericClient>(
-                &'a mut self,
-                client: &'a C,
-                params: &'a impl cornucopia_client::async_::Params<
-                    'a,
-                    Self,
-                    Optioni32Query<'a, C, Option<i32>, 2>,
-                    C,
-                >,
-            ) -> Optioni32Query<'a, C, Option<i32>, 2> {
-                params.bind(client, self)
-            }
         }
         impl<'a, C: GenericClient>
             cornucopia_client::async_::Params<
                 'a,
-                ImplicitCompactStmt,
+                ImplicitCompactParams<'a>,
                 Optioni32Query<'a, C, Option<i32>, 2>,
                 C,
-            > for ImplicitCompactParams<'a>
+            > for ImplicitCompactStmt
         {
-            fn bind(
-                &'a self,
+            fn params(
+                &'a mut self,
                 client: &'a C,
-                stmt: &'a mut ImplicitCompactStmt,
+                params: &'a ImplicitCompactParams<'a>,
             ) -> Optioni32Query<'a, C, Option<i32>, 2> {
-                stmt.bind(client, &self.name, &self.price)
+                self.bind(client, &params.name, &params.price)
             }
         }
         pub fn implicit_spaced() -> ImplicitSpacedStmt {
@@ -4132,33 +4014,21 @@ pub mod queries {
                     mapper: |it| it,
                 }
             }
-            pub fn params<'a, C: GenericClient>(
-                &'a mut self,
-                client: &'a C,
-                params: &'a impl cornucopia_client::async_::Params<
-                    'a,
-                    Self,
-                    Optioni32Query<'a, C, Option<i32>, 2>,
-                    C,
-                >,
-            ) -> Optioni32Query<'a, C, Option<i32>, 2> {
-                params.bind(client, self)
-            }
         }
         impl<'a, C: GenericClient>
             cornucopia_client::async_::Params<
                 'a,
-                ImplicitSpacedStmt,
+                ImplicitSpacedParams<'a>,
                 Optioni32Query<'a, C, Option<i32>, 2>,
                 C,
-            > for ImplicitSpacedParams<'a>
+            > for ImplicitSpacedStmt
         {
-            fn bind(
-                &'a self,
+            fn params(
+                &'a mut self,
                 client: &'a C,
-                stmt: &'a mut ImplicitSpacedStmt,
+                params: &'a ImplicitSpacedParams<'a>,
             ) -> Optioni32Query<'a, C, Option<i32>, 2> {
-                stmt.bind(client, &self.name, &self.price)
+                self.bind(client, &params.name, &params.price)
             }
         }
         pub fn named_compact() -> NamedCompactStmt {
@@ -4182,24 +4052,17 @@ pub mod queries {
                     mapper: |it| <Row>::from(it),
                 }
             }
-            pub fn params<'a, C: GenericClient>(
-                &'a mut self,
-                client: &'a C,
-                params: &'a impl cornucopia_client::async_::Params<'a, Self, RowQuery<'a, C, Row, 2>, C>,
-            ) -> RowQuery<'a, C, Row, 2> {
-                params.bind(client, self)
-            }
         }
         impl<'a, C: GenericClient>
-            cornucopia_client::async_::Params<'a, NamedCompactStmt, RowQuery<'a, C, Row, 2>, C>
-            for Params<'a>
+            cornucopia_client::async_::Params<'a, Params<'a>, RowQuery<'a, C, Row, 2>, C>
+            for NamedCompactStmt
         {
-            fn bind(
-                &'a self,
+            fn params(
+                &'a mut self,
                 client: &'a C,
-                stmt: &'a mut NamedCompactStmt,
+                params: &'a Params<'a>,
             ) -> RowQuery<'a, C, Row, 2> {
-                stmt.bind(client, &self.name, &self.price)
+                self.bind(client, &params.name, &params.price)
             }
         }
         pub fn named_spaced() -> NamedSpacedStmt {
@@ -4223,33 +4086,21 @@ pub mod queries {
                     mapper: |it| <RowSpace>::from(it),
                 }
             }
-            pub fn params<'a, C: GenericClient>(
-                &'a mut self,
-                client: &'a C,
-                params: &'a impl cornucopia_client::async_::Params<
-                    'a,
-                    Self,
-                    RowSpaceQuery<'a, C, RowSpace, 2>,
-                    C,
-                >,
-            ) -> RowSpaceQuery<'a, C, RowSpace, 2> {
-                params.bind(client, self)
-            }
         }
         impl<'a, C: GenericClient>
             cornucopia_client::async_::Params<
                 'a,
-                NamedSpacedStmt,
+                ParamsSpace<'a>,
                 RowSpaceQuery<'a, C, RowSpace, 2>,
                 C,
-            > for ParamsSpace<'a>
+            > for NamedSpacedStmt
         {
-            fn bind(
-                &'a self,
+            fn params(
+                &'a mut self,
                 client: &'a C,
-                stmt: &'a mut NamedSpacedStmt,
+                params: &'a ParamsSpace<'a>,
             ) -> RowSpaceQuery<'a, C, RowSpace, 2> {
-                stmt.bind(client, &self.name, &self.price)
+                self.bind(client, &params.name, &params.price)
             }
         }
         pub fn tricky_sql() -> TrickySqlStmt {

--- a/codegen_test/src/cornucopia_sync.rs
+++ b/codegen_test/src/cornucopia_sync.rs
@@ -1280,42 +1280,31 @@ pub mod queries {
                     ],
                 )
             }
-            pub fn params<'a, C: GenericClient>(
-                &'a mut self,
-                client: &'a mut C,
-                params: &'a impl cornucopia_client::sync::Params<
-                    'a,
-                    Self,
-                    Result<u64, postgres::Error>,
-                    C,
-                >,
-            ) -> Result<u64, postgres::Error> {
-                params.bind(client, self)
-            }
         }
         impl<'a, C: GenericClient>
             cornucopia_client::sync::Params<
                 'a,
-                InsertNightmareDomainStmt,
+                InsertNightmareDomainParams<'a>,
                 Result<u64, postgres::Error>,
                 C,
-            > for InsertNightmareDomainParams<'a>
+            > for InsertNightmareDomainStmt
         {
-            fn bind(
-                &'a self,
+            fn params(
+                &'a mut self,
                 client: &'a mut C,
-                stmt: &'a mut InsertNightmareDomainStmt,
+                params: &'a InsertNightmareDomainParams<'a>,
             ) -> Result<u64, postgres::Error> {
-                stmt.bind(
+                self.bind(
                     client,
-                    &self.txt,
-                    &self.json,
-                    &self.nb,
-                    &self.arr,
-                    &self.composite,
+                    &params.txt,
+                    &params.json,
+                    &params.nb,
+                    &params.arr,
+                    &params.composite,
                 )
             }
         }
+
         pub fn select_nightmare_domain_null() -> SelectNightmareDomainNullStmt {
             SelectNightmareDomainNullStmt(cornucopia_client::sync::Stmt::new(
                 "SELECT * FROM nightmare_domain",
@@ -1570,24 +1559,17 @@ pub mod queries {
                     mapper: |it| <Id>::from(it),
                 }
             }
-            pub fn params<'a, C: GenericClient>(
-                &'a mut self,
-                client: &'a mut C,
-                params: &'a impl cornucopia_client::sync::Params<'a, Self, IdQuery<'a, C, Id, 2>, C>,
-            ) -> IdQuery<'a, C, Id, 2> {
-                params.bind(client, self)
-            }
         }
         impl<'a, C: GenericClient>
-            cornucopia_client::sync::Params<'a, NewNamedVisibleStmt, IdQuery<'a, C, Id, 2>, C>
-            for NamedParams<'a>
+            cornucopia_client::sync::Params<'a, NamedParams<'a>, IdQuery<'a, C, Id, 2>, C>
+            for NewNamedVisibleStmt
         {
-            fn bind(
-                &'a self,
+            fn params(
+                &'a mut self,
                 client: &'a mut C,
-                stmt: &'a mut NewNamedVisibleStmt,
+                params: &'a NamedParams<'a>,
             ) -> IdQuery<'a, C, Id, 2> {
-                stmt.bind(client, &self.name, &self.price)
+                self.bind(client, &params.name, &params.price)
             }
         }
         pub fn new_named_hidden() -> NewNamedHiddenStmt {
@@ -1611,24 +1593,17 @@ pub mod queries {
                     mapper: |it| <Id>::from(it),
                 }
             }
-            pub fn params<'a, C: GenericClient>(
-                &'a mut self,
-                client: &'a mut C,
-                params: &'a impl cornucopia_client::sync::Params<'a, Self, IdQuery<'a, C, Id, 2>, C>,
-            ) -> IdQuery<'a, C, Id, 2> {
-                params.bind(client, self)
-            }
         }
         impl<'a, C: GenericClient>
-            cornucopia_client::sync::Params<'a, NewNamedHiddenStmt, IdQuery<'a, C, Id, 2>, C>
-            for NamedParams<'a>
+            cornucopia_client::sync::Params<'a, NamedParams<'a>, IdQuery<'a, C, Id, 2>, C>
+            for NewNamedHiddenStmt
         {
-            fn bind(
-                &'a self,
+            fn params(
+                &'a mut self,
                 client: &'a mut C,
-                stmt: &'a mut NewNamedHiddenStmt,
+                params: &'a NamedParams<'a>,
             ) -> IdQuery<'a, C, Id, 2> {
-                stmt.bind(client, &self.price, &self.name)
+                self.bind(client, &params.price, &params.name)
             }
         }
         pub fn named() -> NamedStmt {
@@ -1695,35 +1670,24 @@ pub mod queries {
                 let stmt = self.0.prepare(client)?;
                 client.execute(stmt, &[named])
             }
-            pub fn params<'a, C: GenericClient>(
-                &'a mut self,
-                client: &'a mut C,
-                params: &'a impl cornucopia_client::sync::Params<
-                    'a,
-                    Self,
-                    Result<u64, postgres::Error>,
-                    C,
-                >,
-            ) -> Result<u64, postgres::Error> {
-                params.bind(client, self)
-            }
         }
         impl<'a, C: GenericClient>
             cornucopia_client::sync::Params<
                 'a,
-                NewNamedComplexStmt,
+                NamedComplexParams<'a>,
                 Result<u64, postgres::Error>,
                 C,
-            > for NamedComplexParams<'a>
+            > for NewNamedComplexStmt
         {
-            fn bind(
-                &'a self,
+            fn params(
+                &'a mut self,
                 client: &'a mut C,
-                stmt: &'a mut NewNamedComplexStmt,
+                params: &'a NamedComplexParams<'a>,
             ) -> Result<u64, postgres::Error> {
-                stmt.bind(client, &self.named)
+                self.bind(client, &params.named)
             }
         }
+
         pub fn named_complex() -> NamedComplexStmt {
             NamedComplexStmt(cornucopia_client::sync::Stmt::new(
                 "SELECT * FROM named_complex",
@@ -1853,31 +1817,20 @@ pub mod queries {
                 let stmt = self.0.prepare(client)?;
                 client.execute(stmt, &[texts, name, composite])
             }
-            pub fn params<'a, C: GenericClient>(
-                &'a mut self,
-                client: &'a mut C,
-                params: &'a impl cornucopia_client::sync::Params<
-                    'a,
-                    Self,
-                    Result<u64, postgres::Error>,
-                    C,
-                >,
-            ) -> Result<u64, postgres::Error> {
-                params.bind(client, self)
-            }
         }
         impl<'a, C: GenericClient>
-            cornucopia_client::sync::Params<'a, NewNullityStmt, Result<u64, postgres::Error>, C>
-            for NullityParams<'a>
+            cornucopia_client::sync::Params<'a, NullityParams<'a>, Result<u64, postgres::Error>, C>
+            for NewNullityStmt
         {
-            fn bind(
-                &'a self,
+            fn params(
+                &'a mut self,
                 client: &'a mut C,
-                stmt: &'a mut NewNullityStmt,
+                params: &'a NullityParams<'a>,
             ) -> Result<u64, postgres::Error> {
-                stmt.bind(client, &self.texts, &self.name, &self.composite)
+                self.bind(client, &params.texts, &params.name, &params.composite)
             }
         }
+
         pub fn nullity() -> NullityStmt {
             NullityStmt(cornucopia_client::sync::Stmt::new("SELECT * FROM nullity"))
         }
@@ -2002,31 +1955,24 @@ pub mod queries {
                 let stmt = self.0.prepare(client)?;
                 client.execute(stmt, &[author, name])
             }
-            pub fn params<'a, C: GenericClient>(
-                &'a mut self,
-                client: &'a mut C,
-                params: &'a impl cornucopia_client::sync::Params<
-                    'a,
-                    Self,
-                    Result<u64, postgres::Error>,
-                    C,
-                >,
-            ) -> Result<u64, postgres::Error> {
-                params.bind(client, self)
-            }
         }
         impl<'a, C: GenericClient>
-            cornucopia_client::sync::Params<'a, InsertBookStmt, Result<u64, postgres::Error>, C>
-            for InsertBookParams<'a>
+            cornucopia_client::sync::Params<
+                'a,
+                InsertBookParams<'a>,
+                Result<u64, postgres::Error>,
+                C,
+            > for InsertBookStmt
         {
-            fn bind(
-                &'a self,
+            fn params(
+                &'a mut self,
                 client: &'a mut C,
-                stmt: &'a mut InsertBookStmt,
+                params: &'a InsertBookParams<'a>,
             ) -> Result<u64, postgres::Error> {
-                stmt.bind(client, &self.author, &self.name)
+                self.bind(client, &params.author, &params.name)
             }
         }
+
         pub fn select_book() -> SelectBookStmt {
             SelectBookStmt(cornucopia_client::sync::Stmt::new("SELECT * FROM book"))
         }
@@ -2080,29 +2026,17 @@ pub mod queries {
                 let stmt = self.0.prepare(client)?;
                 client.execute(stmt, &[c, a])
             }
-            pub fn params<'a, C: GenericClient>(
-                &'a mut self,
-                client: &'a mut C,
-                params: &'a impl cornucopia_client::sync::Params<
-                    'a,
-                    Self,
-                    Result<u64, postgres::Error>,
-                    C,
-                >,
-            ) -> Result<u64, postgres::Error> {
-                params.bind(client, self)
-            }
         }
         impl<'a, C: GenericClient>
-            cornucopia_client::sync::Params<'a, ParamsOrderStmt, Result<u64, postgres::Error>, C>
-            for ParamsOrderParams
+            cornucopia_client::sync::Params<'a, ParamsOrderParams, Result<u64, postgres::Error>, C>
+            for ParamsOrderStmt
         {
-            fn bind(
-                &'a self,
+            fn params(
+                &'a mut self,
                 client: &'a mut C,
-                stmt: &'a mut ParamsOrderStmt,
+                params: &'a ParamsOrderParams,
             ) -> Result<u64, postgres::Error> {
-                stmt.bind(client, &self.c, &self.a)
+                self.bind(client, &params.c, &params.a)
             }
         }
     }
@@ -3215,70 +3149,59 @@ pub mod queries {
                     ],
                 )
             }
-            pub fn params<'a, C: GenericClient>(
-                &'a mut self,
-                client: &'a mut C,
-                params: &'a impl cornucopia_client::sync::Params<
-                    'a,
-                    Self,
-                    Result<u64, postgres::Error>,
-                    C,
-                >,
-            ) -> Result<u64, postgres::Error> {
-                params.bind(client, self)
-            }
         }
         impl<'a, C: GenericClient>
             cornucopia_client::sync::Params<
                 'a,
-                InsertEverythingStmt,
+                EverythingParams<'a>,
                 Result<u64, postgres::Error>,
                 C,
-            > for EverythingParams<'a>
+            > for InsertEverythingStmt
         {
-            fn bind(
-                &'a self,
+            fn params(
+                &'a mut self,
                 client: &'a mut C,
-                stmt: &'a mut InsertEverythingStmt,
+                params: &'a EverythingParams<'a>,
             ) -> Result<u64, postgres::Error> {
-                stmt.bind(
+                self.bind(
                     client,
-                    &self.bool_,
-                    &self.boolean_,
-                    &self.char_,
-                    &self.smallint_,
-                    &self.int2_,
-                    &self.smallserial_,
-                    &self.serial2_,
-                    &self.int_,
-                    &self.int4_,
-                    &self.serial_,
-                    &self.serial4_,
-                    &self.bingint_,
-                    &self.int8_,
-                    &self.bigserial_,
-                    &self.serial8_,
-                    &self.float4_,
-                    &self.real_,
-                    &self.float8_,
-                    &self.double_precision_,
-                    &self.text_,
-                    &self.varchar_,
-                    &self.bytea_,
-                    &self.timestamp_,
-                    &self.timestamp_without_time_zone_,
-                    &self.timestamptz_,
-                    &self.timestamp_with_time_zone_,
-                    &self.date_,
-                    &self.time_,
-                    &self.json_,
-                    &self.jsonb_,
-                    &self.uuid_,
-                    &self.inet_,
-                    &self.macaddr_,
+                    &params.bool_,
+                    &params.boolean_,
+                    &params.char_,
+                    &params.smallint_,
+                    &params.int2_,
+                    &params.smallserial_,
+                    &params.serial2_,
+                    &params.int_,
+                    &params.int4_,
+                    &params.serial_,
+                    &params.serial4_,
+                    &params.bingint_,
+                    &params.int8_,
+                    &params.bigserial_,
+                    &params.serial8_,
+                    &params.float4_,
+                    &params.real_,
+                    &params.float8_,
+                    &params.double_precision_,
+                    &params.text_,
+                    &params.varchar_,
+                    &params.bytea_,
+                    &params.timestamp_,
+                    &params.timestamp_without_time_zone_,
+                    &params.timestamptz_,
+                    &params.timestamp_with_time_zone_,
+                    &params.date_,
+                    &params.time_,
+                    &params.json_,
+                    &params.jsonb_,
+                    &params.uuid_,
+                    &params.inet_,
+                    &params.macaddr_,
                 )
             }
         }
+
         pub fn select_everything_array() -> SelectEverythingArrayStmt {
             SelectEverythingArrayStmt(cornucopia_client::sync::Stmt::new(
                 "SELECT * FROM EverythingArray",
@@ -3446,64 +3369,53 @@ pub mod queries {
                     ],
                 )
             }
-            pub fn params<'a, C: GenericClient>(
-                &'a mut self,
-                client: &'a mut C,
-                params: &'a impl cornucopia_client::sync::Params<
-                    'a,
-                    Self,
-                    Result<u64, postgres::Error>,
-                    C,
-                >,
-            ) -> Result<u64, postgres::Error> {
-                params.bind(client, self)
-            }
         }
         impl<'a, C: GenericClient>
             cornucopia_client::sync::Params<
                 'a,
-                InsertEverythingArrayStmt,
+                EverythingArrayParams<'a>,
                 Result<u64, postgres::Error>,
                 C,
-            > for EverythingArrayParams<'a>
+            > for InsertEverythingArrayStmt
         {
-            fn bind(
-                &'a self,
+            fn params(
+                &'a mut self,
                 client: &'a mut C,
-                stmt: &'a mut InsertEverythingArrayStmt,
+                params: &'a EverythingArrayParams<'a>,
             ) -> Result<u64, postgres::Error> {
-                stmt.bind(
+                self.bind(
                     client,
-                    &self.bool_,
-                    &self.boolean_,
-                    &self.char_,
-                    &self.smallint_,
-                    &self.int2_,
-                    &self.int_,
-                    &self.int4_,
-                    &self.bingint_,
-                    &self.int8_,
-                    &self.float4_,
-                    &self.real_,
-                    &self.float8_,
-                    &self.double_precision_,
-                    &self.text_,
-                    &self.varchar_,
-                    &self.bytea_,
-                    &self.timestamp_,
-                    &self.timestamp_without_time_zone_,
-                    &self.timestamptz_,
-                    &self.timestamp_with_time_zone_,
-                    &self.date_,
-                    &self.time_,
-                    &self.json_,
-                    &self.jsonb_,
-                    &self.uuid_,
-                    &self.inet_,
-                    &self.macaddr_,
+                    &params.bool_,
+                    &params.boolean_,
+                    &params.char_,
+                    &params.smallint_,
+                    &params.int2_,
+                    &params.int_,
+                    &params.int4_,
+                    &params.bingint_,
+                    &params.int8_,
+                    &params.float4_,
+                    &params.real_,
+                    &params.float8_,
+                    &params.double_precision_,
+                    &params.text_,
+                    &params.varchar_,
+                    &params.bytea_,
+                    &params.timestamp_,
+                    &params.timestamp_without_time_zone_,
+                    &params.timestamptz_,
+                    &params.timestamp_with_time_zone_,
+                    &params.date_,
+                    &params.time_,
+                    &params.json_,
+                    &params.jsonb_,
+                    &params.uuid_,
+                    &params.inet_,
+                    &params.macaddr_,
                 )
             }
         }
+
         pub fn select_nightmare() -> SelectNightmareStmt {
             SelectNightmareStmt(cornucopia_client::sync::Stmt::new(
                 "SELECT * FROM nightmare",
@@ -3927,33 +3839,21 @@ pub mod queries {
                     mapper: |it| it,
                 }
             }
-            pub fn params<'a, C: GenericClient>(
-                &'a mut self,
-                client: &'a mut C,
-                params: &'a impl cornucopia_client::sync::Params<
-                    'a,
-                    Self,
-                    Optioni32Query<'a, C, Option<i32>, 2>,
-                    C,
-                >,
-            ) -> Optioni32Query<'a, C, Option<i32>, 2> {
-                params.bind(client, self)
-            }
         }
         impl<'a, C: GenericClient>
             cornucopia_client::sync::Params<
                 'a,
-                ImplicitCompactStmt,
+                ImplicitCompactParams<'a>,
                 Optioni32Query<'a, C, Option<i32>, 2>,
                 C,
-            > for ImplicitCompactParams<'a>
+            > for ImplicitCompactStmt
         {
-            fn bind(
-                &'a self,
+            fn params(
+                &'a mut self,
                 client: &'a mut C,
-                stmt: &'a mut ImplicitCompactStmt,
+                params: &'a ImplicitCompactParams<'a>,
             ) -> Optioni32Query<'a, C, Option<i32>, 2> {
-                stmt.bind(client, &self.name, &self.price)
+                self.bind(client, &params.name, &params.price)
             }
         }
         pub fn implicit_spaced() -> ImplicitSpacedStmt {
@@ -3977,33 +3877,21 @@ pub mod queries {
                     mapper: |it| it,
                 }
             }
-            pub fn params<'a, C: GenericClient>(
-                &'a mut self,
-                client: &'a mut C,
-                params: &'a impl cornucopia_client::sync::Params<
-                    'a,
-                    Self,
-                    Optioni32Query<'a, C, Option<i32>, 2>,
-                    C,
-                >,
-            ) -> Optioni32Query<'a, C, Option<i32>, 2> {
-                params.bind(client, self)
-            }
         }
         impl<'a, C: GenericClient>
             cornucopia_client::sync::Params<
                 'a,
-                ImplicitSpacedStmt,
+                ImplicitSpacedParams<'a>,
                 Optioni32Query<'a, C, Option<i32>, 2>,
                 C,
-            > for ImplicitSpacedParams<'a>
+            > for ImplicitSpacedStmt
         {
-            fn bind(
-                &'a self,
+            fn params(
+                &'a mut self,
                 client: &'a mut C,
-                stmt: &'a mut ImplicitSpacedStmt,
+                params: &'a ImplicitSpacedParams<'a>,
             ) -> Optioni32Query<'a, C, Option<i32>, 2> {
-                stmt.bind(client, &self.name, &self.price)
+                self.bind(client, &params.name, &params.price)
             }
         }
         pub fn named_compact() -> NamedCompactStmt {
@@ -4027,24 +3915,17 @@ pub mod queries {
                     mapper: |it| <Row>::from(it),
                 }
             }
-            pub fn params<'a, C: GenericClient>(
-                &'a mut self,
-                client: &'a mut C,
-                params: &'a impl cornucopia_client::sync::Params<'a, Self, RowQuery<'a, C, Row, 2>, C>,
-            ) -> RowQuery<'a, C, Row, 2> {
-                params.bind(client, self)
-            }
         }
         impl<'a, C: GenericClient>
-            cornucopia_client::sync::Params<'a, NamedCompactStmt, RowQuery<'a, C, Row, 2>, C>
-            for Params<'a>
+            cornucopia_client::sync::Params<'a, Params<'a>, RowQuery<'a, C, Row, 2>, C>
+            for NamedCompactStmt
         {
-            fn bind(
-                &'a self,
+            fn params(
+                &'a mut self,
                 client: &'a mut C,
-                stmt: &'a mut NamedCompactStmt,
+                params: &'a Params<'a>,
             ) -> RowQuery<'a, C, Row, 2> {
-                stmt.bind(client, &self.name, &self.price)
+                self.bind(client, &params.name, &params.price)
             }
         }
         pub fn named_spaced() -> NamedSpacedStmt {
@@ -4068,33 +3949,21 @@ pub mod queries {
                     mapper: |it| <RowSpace>::from(it),
                 }
             }
-            pub fn params<'a, C: GenericClient>(
-                &'a mut self,
-                client: &'a mut C,
-                params: &'a impl cornucopia_client::sync::Params<
-                    'a,
-                    Self,
-                    RowSpaceQuery<'a, C, RowSpace, 2>,
-                    C,
-                >,
-            ) -> RowSpaceQuery<'a, C, RowSpace, 2> {
-                params.bind(client, self)
-            }
         }
         impl<'a, C: GenericClient>
             cornucopia_client::sync::Params<
                 'a,
-                NamedSpacedStmt,
+                ParamsSpace<'a>,
                 RowSpaceQuery<'a, C, RowSpace, 2>,
                 C,
-            > for ParamsSpace<'a>
+            > for NamedSpacedStmt
         {
-            fn bind(
-                &'a self,
+            fn params(
+                &'a mut self,
                 client: &'a mut C,
-                stmt: &'a mut NamedSpacedStmt,
+                params: &'a ParamsSpace<'a>,
             ) -> RowSpaceQuery<'a, C, RowSpace, 2> {
-                stmt.bind(client, &self.name, &self.price)
+                self.bind(client, &params.name, &params.price)
             }
         }
         pub fn tricky_sql() -> TrickySqlStmt {

--- a/codegen_test/src/main.rs
+++ b/codegen_test/src/main.rs
@@ -8,6 +8,7 @@ use std::net::{IpAddr, Ipv4Addr};
 use time::{OffsetDateTime, PrimitiveDateTime};
 use uuid::Uuid;
 
+use cornucopia_client::sync::Params;
 use crate::cornucopia_sync::{
     queries::{
         copy::{insert_clone, insert_copy, select_copy},

--- a/codegen_test/src/main.rs
+++ b/codegen_test/src/main.rs
@@ -8,7 +8,6 @@ use std::net::{IpAddr, Ipv4Addr};
 use time::{OffsetDateTime, PrimitiveDateTime};
 use uuid::Uuid;
 
-use cornucopia_client::sync::Params;
 use crate::cornucopia_sync::{
     queries::{
         copy::{insert_clone, insert_copy, select_copy},
@@ -37,6 +36,7 @@ use crate::cornucopia_sync::{
         SpongebobCharacter,
     },
 };
+use cornucopia_client::sync::Params;
 
 pub fn main() {
     let client = &mut Config::new()

--- a/cornucopia/src/codegen.rs
+++ b/cornucopia/src/codegen.rs
@@ -491,19 +491,20 @@ fn gen_query_fn(
                 }}"
                 );
             } else {
-                let (pre_ty, post_ty_lf, pre, post) = if is_async {
+                let (send_sync, pre_ty, post_ty_lf, pre, post) = if is_async {
                     (
+                        "+ Send + Sync",
                         "std::pin::Pin<Box<dyn futures::Future<Output = ",
-                        "> + 'a>>",
+                        "> + Send + 'a>>",
                         "Box::pin(",
                         ")",
                     )
                 } else {
-                    ("", "", "", "")
+                    ("", "", "", "", "")
                 };
                 gen!(
                     w,
-                    "impl <'a, C: GenericClient> cornucopia_client::{mod_name}::Params<'a, {param_name}{lifetime}, {pre_ty}Result<u64, {backend}::Error>{post_ty_lf}, C> for {struct_name}Stmt  {{ 
+                    "impl <'a, C: GenericClient {send_sync}> cornucopia_client::{mod_name}::Params<'a, {param_name}{lifetime}, {pre_ty}Result<u64, {backend}::Error>{post_ty_lf}, C> for {struct_name}Stmt  {{ 
                         fn params(&'a mut self, client: &'a {client_mut} C, params: &'a {param_name}{lifetime}) -> {pre_ty}Result<u64, {backend}::Error>{post_ty_lf} {{
                             {pre}self.bind(client, {param_values}){post}
                         }}

--- a/cornucopia_client/src/async_.rs
+++ b/cornucopia_client/src/async_.rs
@@ -198,6 +198,8 @@ impl Stmt {
     }
 }
 
+/// This trait allows you to bind parameters to a query using a single
+/// struct, rather than passing each bind parameter as a function parameter.
 pub trait Params<'a, P, O, C> {
     fn params(&'a mut self, client: &'a C, params: &'a P) -> O;
 }

--- a/cornucopia_client/src/async_.rs
+++ b/cornucopia_client/src/async_.rs
@@ -198,6 +198,6 @@ impl Stmt {
     }
 }
 
-pub trait Params<'a, S, O, C> {
-    fn bind(&'a self, client: &'a C, stmt: &'a mut S) -> O;
+pub trait Params<'a, P, O, C> {
+    fn params(&'a mut self, client: &'a C, params: &'a P) -> O;
 }

--- a/cornucopia_client/src/async_.rs
+++ b/cornucopia_client/src/async_.rs
@@ -9,7 +9,7 @@ use tokio_postgres::{
 /// In addition, when the `deadpool` feature is enabled (default), this trait also
 /// abstracts over deadpool clients and transactions
 #[async_trait]
-pub trait GenericClient {
+pub trait GenericClient: Send + Sync {
     async fn prepare(&self, query: &str) -> Result<Statement, Error>;
     async fn execute<T>(
         &self,

--- a/cornucopia_client/src/lib.rs
+++ b/cornucopia_client/src/lib.rs
@@ -1,5 +1,10 @@
 mod array_iterator;
 
+/// Hidden modules
+///
+/// The following modules are public because the generated code needs
+/// to access them, but users should not depend on them.
+
 #[cfg(feature = "async")]
 #[doc(hidden)]
 pub mod async_;
@@ -15,7 +20,19 @@ pub mod sync;
 #[doc(hidden)]
 pub mod private;
 
+/// Public items
+///
+/// These items are the real public part of the API.
 pub use array_iterator::ArrayIterator;
 
 #[cfg(feature = "async")]
 pub use async_::GenericClient;
+
+#[cfg(all(feature = "async", not(feature = "sync")))]
+pub use async_::Params;
+#[cfg(all(feature = "sync", feature = "async"))]
+pub use async_::Params as AsyncParams;
+#[cfg(all(feature = "sync", not(feature = "async")))]
+pub use sync::Params;
+#[cfg(all(feature = "sync", feature = "async"))]
+pub use sync::Params as SyncParams;

--- a/cornucopia_client/src/sync.rs
+++ b/cornucopia_client/src/sync.rs
@@ -28,6 +28,6 @@ impl Stmt {
     }
 }
 
-pub trait Params<'a, S, O, C> {
-    fn bind(&'a self, client: &'a mut C, stmt: &'a mut S) -> O;
+pub trait Params<'a, P, O, C> {
+    fn params(&'a mut self, client: &'a mut C, params: &'a P) -> O;
 }

--- a/cornucopia_client/src/sync.rs
+++ b/cornucopia_client/src/sync.rs
@@ -28,6 +28,8 @@ impl Stmt {
     }
 }
 
+/// This trait allows you to bind parameters to a query using a single
+/// struct, rather than passing each bind parameter as a function parameter.
 pub trait Params<'a, P, O, C> {
     fn params(&'a mut self, client: &'a mut C, params: &'a P) -> O;
 }


### PR DESCRIPTION
I found a better way to generate code for params struct with less boilerplate code and improved usability for async variant