### PR TITLE
✨ Replace generated inner attrs with outer attrs.

### DIFF
--- a/bench/usage/cornucopia_benches/generated_async.rs
+++ b/bench/usage/cornucopia_benches/generated_async.rs
@@ -1,9 +1,14 @@
 // This file was generated with `cornucopia`. Do not modify.
-#![allow(clippy::all, clippy::pedantic)]
-#![allow(unused_variables)]
-#![allow(unused_imports)]
-#![allow(dead_code)]
+
+#[allow(clippy::all, clippy::pedantic)]
+#[allow(unused_variables)]
+#[allow(unused_imports)]
+#[allow(dead_code)]
 pub mod types {}
+#[allow(clippy::all, clippy::pedantic)]
+#[allow(unused_variables)]
+#[allow(unused_imports)]
+#[allow(dead_code)]
 pub mod queries {
     pub mod bench {
         use cornucopia_async::GenericClient;

--- a/bench/usage/cornucopia_benches/generated_sync.rs
+++ b/bench/usage/cornucopia_benches/generated_sync.rs
@@ -1,9 +1,14 @@
 // This file was generated with `cornucopia`. Do not modify.
-#![allow(clippy::all, clippy::pedantic)]
-#![allow(unused_variables)]
-#![allow(unused_imports)]
-#![allow(dead_code)]
+
+#[allow(clippy::all, clippy::pedantic)]
+#[allow(unused_variables)]
+#[allow(unused_imports)]
+#[allow(dead_code)]
 pub mod types {}
+#[allow(clippy::all, clippy::pedantic)]
+#[allow(unused_variables)]
+#[allow(unused_imports)]
+#[allow(dead_code)]
 pub mod queries {
     pub mod bench {
         use postgres::{fallible_iterator::FallibleIterator, GenericClient};

--- a/codegen_test/src/cornucopia_async.rs
+++ b/codegen_test/src/cornucopia_async.rs
@@ -1,8 +1,9 @@
 // This file was generated with `cornucopia`. Do not modify.
-#![allow(clippy::all, clippy::pedantic)]
-#![allow(unused_variables)]
-#![allow(unused_imports)]
-#![allow(dead_code)]
+
+#[allow(clippy::all, clippy::pedantic)]
+#[allow(unused_variables)]
+#[allow(unused_imports)]
+#[allow(dead_code)]
 pub mod types {
     pub mod public {
         #[derive(serde::Serialize, Debug, postgres_types::FromSql, Clone, PartialEq)]
@@ -839,6 +840,10 @@ pub mod types {
         }
     }
 }
+#[allow(clippy::all, clippy::pedantic)]
+#[allow(unused_variables)]
+#[allow(unused_imports)]
+#[allow(dead_code)]
 pub mod queries {
     pub mod copy {
         use cornucopia_async::GenericClient;

--- a/codegen_test/src/cornucopia_sync.rs
+++ b/codegen_test/src/cornucopia_sync.rs
@@ -1,8 +1,9 @@
 // This file was generated with `cornucopia`. Do not modify.
-#![allow(clippy::all, clippy::pedantic)]
-#![allow(unused_variables)]
-#![allow(unused_imports)]
-#![allow(dead_code)]
+
+#[allow(clippy::all, clippy::pedantic)]
+#[allow(unused_variables)]
+#[allow(unused_imports)]
+#[allow(dead_code)]
 pub mod types {
     pub mod public {
         #[derive(serde::Serialize, Debug, postgres_types::FromSql, Clone, PartialEq)]
@@ -837,6 +838,10 @@ pub mod types {
         }
     }
 }
+#[allow(clippy::all, clippy::pedantic)]
+#[allow(unused_variables)]
+#[allow(unused_imports)]
+#[allow(dead_code)]
 pub mod queries {
     pub mod copy {
         use postgres::{fallible_iterator::FallibleIterator, GenericClient};

--- a/cornucopia/src/codegen.rs
+++ b/cornucopia/src/codegen.rs
@@ -617,7 +617,14 @@ fn gen_type_modules(
         gen!(w, "pub mod {schema} {{ {tys_str} }}");
     });
 
-    gen!(w, "pub mod types {{ {modules_str} }}");
+    gen!(
+        w,
+        "#[allow(clippy::all, clippy::pedantic)]
+    #[allow(unused_variables)]
+    #[allow(unused_imports)]
+    #[allow(dead_code)]
+    pub mod types {{ {modules_str} }}"
+    );
 }
 
 pub(crate) fn generate(preparation: Preparation, settings: CodegenSettings) -> String {
@@ -626,13 +633,7 @@ pub(crate) fn generate(preparation: Preparation, settings: CodegenSettings) -> S
     } else {
         "use postgres::{{fallible_iterator::FallibleIterator,GenericClient}};"
     };
-    let mut buff = "// This file was generated with `cornucopia`. Do not modify.
-    #![allow(clippy::all, clippy::pedantic)]
-    #![allow(unused_variables)]
-    #![allow(unused_imports)]
-    #![allow(dead_code)]
-    "
-    .to_string();
+    let mut buff = "// This file was generated with `cornucopia`. Do not modify.\n\n".to_string();
     // Generate database type
     gen_type_modules(&mut buff, &preparation.types, settings);
     // Generate queries
@@ -652,6 +653,14 @@ pub(crate) fn generate(preparation: Preparation, settings: CodegenSettings) -> S
             module.info.name
         );
     });
-    gen!(&mut buff, "pub mod queries {{ {} }}", query_modules);
+    gen!(
+        &mut buff,
+        "#[allow(clippy::all, clippy::pedantic)]
+    #[allow(unused_variables)]
+    #[allow(unused_imports)]
+    #[allow(dead_code)]
+    pub mod queries {{ {} }}",
+        query_modules
+    );
     buff
 }

--- a/examples/auto_build/src/cornucopia.rs
+++ b/examples/auto_build/src/cornucopia.rs
@@ -1,9 +1,14 @@
 // This file was generated with `cornucopia`. Do not modify.
-#![allow(clippy::all, clippy::pedantic)]
-#![allow(unused_variables)]
-#![allow(unused_imports)]
-#![allow(dead_code)]
+
+#[allow(clippy::all, clippy::pedantic)]
+#[allow(unused_variables)]
+#[allow(unused_imports)]
+#[allow(dead_code)]
 pub mod types {}
+#[allow(clippy::all, clippy::pedantic)]
+#[allow(unused_variables)]
+#[allow(unused_imports)]
+#[allow(dead_code)]
 pub mod queries {
     pub mod module_1 {
         use cornucopia_async::GenericClient;

--- a/examples/basic_async/src/cornucopia.rs
+++ b/examples/basic_async/src/cornucopia.rs
@@ -1,8 +1,9 @@
 // This file was generated with `cornucopia`. Do not modify.
-#![allow(clippy::all, clippy::pedantic)]
-#![allow(unused_variables)]
-#![allow(unused_imports)]
-#![allow(dead_code)]
+
+#[allow(clippy::all, clippy::pedantic)]
+#[allow(unused_variables)]
+#[allow(unused_imports)]
+#[allow(dead_code)]
 pub mod types {
     pub mod public {
         #[derive(
@@ -16,6 +17,10 @@ pub mod types {
         }
     }
 }
+#[allow(clippy::all, clippy::pedantic)]
+#[allow(unused_variables)]
+#[allow(unused_imports)]
+#[allow(dead_code)]
 pub mod queries {
     pub mod module_1 {
         use cornucopia_async::GenericClient;

--- a/examples/basic_sync/src/cornucopia.rs
+++ b/examples/basic_sync/src/cornucopia.rs
@@ -1,8 +1,9 @@
 // This file was generated with `cornucopia`. Do not modify.
-#![allow(clippy::all, clippy::pedantic)]
-#![allow(unused_variables)]
-#![allow(unused_imports)]
-#![allow(dead_code)]
+
+#[allow(clippy::all, clippy::pedantic)]
+#[allow(unused_variables)]
+#[allow(unused_imports)]
+#[allow(dead_code)]
 pub mod types {
     pub mod public {
         #[derive(
@@ -16,6 +17,10 @@ pub mod types {
         }
     }
 }
+#[allow(clippy::all, clippy::pedantic)]
+#[allow(unused_variables)]
+#[allow(unused_imports)]
+#[allow(dead_code)]
 pub mod queries {
     pub mod module_1 {
         use postgres::{fallible_iterator::FallibleIterator, GenericClient};


### PR DESCRIPTION
This is mostly a temporary measure until https://github.com/rust-lang/rfcs/issues/752 gets resolved. The gist is that files containing inner attributes don't work with `include_str` which some of users need as part of their workflow.

The fix applied here is simple: instead of applying to inner attributes to the whole file, we apply them to the two top-level generated modules: `queries` and `types`. This introduces 4 duplicated lines, so not really a big deal :smile:.

Closes #138.