### PR TITLE
fix: Escape enum members containing reserved keywords

### DIFF
--- a/cornucopia/src/validation.rs
+++ b/cornucopia/src/validation.rs
@@ -185,7 +185,7 @@ pub(crate) fn param_on_simple_query(
     Ok(())
 }
 
-const KEYWORD: [&str; 52] = [
+pub(crate) const KEYWORD: [&str; 52] = [
     "Self", "abstract", "as", "async", "await", "become", "box", "break", "const", "continue",
     "crate", "do", "dyn", "else", "enum", "extern", "false", "final", "fn", "for", "if", "impl",
     "in", "let", "loop", "macro", "match", "mod", "move", "mut", "override", "priv", "pub", "ref",


### PR DESCRIPTION
Just stumbled upon an issue where one of the enum members of an existing postgres enum was `box`. Cornucopia happily generated the `cornucopia.rs` file, but the result was a file with a syntax error in it.

So here comes my quick-fix to that.

This PR is not meant to be merged, just demonstrating one way to resolve the issue. I'm a bit short on time so if anyone with more intimate knowledge of the codebase wants to do it properly, then please go ahead 😉