### PR TITLE
Escape rust reserved keywords

### DIFF
--- a/codegen_test/queries/syntax.sql
+++ b/codegen_test/queries/syntax.sql
@@ -47,7 +47,7 @@ INSERT INTO syntax ("trick:y", async, enum) VALUES (E'this is \'not\' a \':bind_
 --! tricky_sql10
 INSERT INTO syntax ("trick:y", async, enum) VALUES ('this is just a cast'::text, :async, :enum);
 
---! syntax
+--! typeof
 SELECT * FROM syntax;
 
 -- Multi

--- a/codegen_test/queries/syntax.sql
+++ b/codegen_test/queries/syntax.sql
@@ -27,29 +27,28 @@ INSERT INTO named (name, price, show) VALUES (:name, :price, false) RETURNING id
 INSERT INTO named (name, price, show) VALUES (:name, :price, false) RETURNING id;
 
 --! tricky_sql
-INSERT INTO syntax ("trick:y", price) VALUES ('this is not a bind_param\', :price);
+INSERT INTO syntax ("trick:y", async, enum) VALUES ('this is not a bind_param\', :async, :enum);
 --! tricky_sql1
-INSERT INTO syntax ("trick:y", price) VALUES ('this is not a :bind_param', :price);
+INSERT INTO syntax ("trick:y", async, enum) VALUES ('this is not a :bind_param', :async, :enum);
 --! tricky_sql2
-INSERT INTO syntax ("trick:y", price) VALUES ('this is not a '':bind_param''', :price);
+INSERT INTO syntax ("trick:y", async, enum) VALUES ('this is not a '':bind_param''', :async, :enum);
 --! tricky_sql3
-INSERT INTO syntax ("trick:y", price)  VALUES ($$this is not a :bind_param$$, :price);
+INSERT INTO syntax ("trick:y", async, enum)  VALUES ($$this is not a :bind_param$$, :async, :enum);
 --! tricky_sql4
-INSERT INTO syntax ("trick:y", price) VALUES ($tag$this is not a :bind_param$tag$, :price);
+INSERT INTO syntax ("trick:y", async, enum) VALUES ($tag$this is not a :bind_param$tag$, :async, :enum);
 --! tricky_sql6
-INSERT INTO syntax ("trick:y", price) VALUES (e'this is not a '':bind_param''', :price);
+INSERT INTO syntax ("trick:y", async, enum) VALUES (e'this is not a '':bind_param''', :async, :enum);
 --! tricky_sql7
-INSERT INTO syntax ("trick:y", price) VALUES (E'this is not a \':bind_param\'', :price);
+INSERT INTO syntax ("trick:y", async, enum) VALUES (E'this is not a \':bind_param\'', :async, :enum);
 --! tricky_sql8
-INSERT INTO syntax ("trick:y", price) VALUES (e'this is ''not'' a \':bind_param\'', :price);
+INSERT INTO syntax ("trick:y", async, enum) VALUES (e'this is ''not'' a \':bind_param\'', :async, :enum);
 --! tricky_sql9
-INSERT INTO syntax ("trick:y", price) VALUES (E'this is \'not\' a \':bind_param\'', :price);
+INSERT INTO syntax ("trick:y", async, enum) VALUES (E'this is \'not\' a \':bind_param\'', :async, :enum);
 --! tricky_sql10
-INSERT INTO syntax ("trick:y", price) VALUES ('this is just a cast'::text, :price);
+INSERT INTO syntax ("trick:y", async, enum) VALUES ('this is just a cast'::text, :async, :enum);
 
 --! syntax
 SELECT * FROM syntax;
-
 
 -- Multi
 

--- a/codegen_test/schema.sql
+++ b/codegen_test/schema.sql
@@ -181,7 +181,12 @@ CREATE TABLE nightmare (
 
 -- Syntax
 
+CREATE TYPE syntax_composite AS (
+    async INT
+);
+CREATE TYPE syntax_enum AS Enum('async', 'box');
 CREATE TABLE Syntax (
     "trick:y" TEXT,
-    price FLOAT
+    async syntax_composite,
+    enum syntax_enum
 );

--- a/codegen_test/src/cornucopia_async.rs
+++ b/codegen_test/src/cornucopia_async.rs
@@ -4469,23 +4469,23 @@ pub mod queries {
             }
         }
         #[derive(serde::Serialize, Debug, Clone, PartialEq)]
-        pub struct Syntax {
+        pub struct Typeof {
             pub trick_y: String,
             pub r#async: super::super::types::public::SyntaxComposite,
             pub r#enum: super::super::types::public::SyntaxEnum,
         }
-        pub struct SyntaxBorrowed<'a> {
+        pub struct TypeofBorrowed<'a> {
             pub trick_y: &'a str,
             pub r#async: super::super::types::public::SyntaxComposite,
             pub r#enum: super::super::types::public::SyntaxEnum,
         }
-        impl<'a> From<SyntaxBorrowed<'a>> for Syntax {
+        impl<'a> From<TypeofBorrowed<'a>> for Typeof {
             fn from(
-                SyntaxBorrowed {
+                TypeofBorrowed {
                     trick_y,
                     r#async,
                     r#enum,
-                }: SyntaxBorrowed<'a>,
+                }: TypeofBorrowed<'a>,
             ) -> Self {
                 Self {
                     trick_y: trick_y.into(),
@@ -4494,19 +4494,19 @@ pub mod queries {
                 }
             }
         }
-        pub struct SyntaxQuery<'a, C: GenericClient, T, const N: usize> {
+        pub struct TypeofQuery<'a, C: GenericClient, T, const N: usize> {
             client: &'a C,
             params: [&'a (dyn postgres_types::ToSql + Sync); N],
             stmt: &'a mut cornucopia_async::private::Stmt,
-            extractor: fn(&tokio_postgres::Row) -> SyntaxBorrowed,
-            mapper: fn(SyntaxBorrowed) -> T,
+            extractor: fn(&tokio_postgres::Row) -> TypeofBorrowed,
+            mapper: fn(TypeofBorrowed) -> T,
         }
-        impl<'a, C, T: 'a, const N: usize> SyntaxQuery<'a, C, T, N>
+        impl<'a, C, T: 'a, const N: usize> TypeofQuery<'a, C, T, N>
         where
             C: GenericClient,
         {
-            pub fn map<R>(self, mapper: fn(SyntaxBorrowed) -> R) -> SyntaxQuery<'a, C, R, N> {
-                SyntaxQuery {
+            pub fn map<R>(self, mapper: fn(TypeofBorrowed) -> R) -> TypeofQuery<'a, C, R, N> {
+                TypeofQuery {
                     client: self.client,
                     params: self.params,
                     stmt: self.stmt,
@@ -5142,25 +5142,25 @@ pub mod queries {
             }
         }
 
-        pub fn syntax() -> SyntaxStmt {
-            SyntaxStmt(cornucopia_async::private::Stmt::new("SELECT * FROM syntax"))
+        pub fn r#typeof() -> TypeofStmt {
+            TypeofStmt(cornucopia_async::private::Stmt::new("SELECT * FROM syntax"))
         }
-        pub struct SyntaxStmt(cornucopia_async::private::Stmt);
-        impl SyntaxStmt {
+        pub struct TypeofStmt(cornucopia_async::private::Stmt);
+        impl TypeofStmt {
             pub fn bind<'a, C: GenericClient>(
                 &'a mut self,
                 client: &'a C,
-            ) -> SyntaxQuery<'a, C, Syntax, 0> {
-                SyntaxQuery {
+            ) -> TypeofQuery<'a, C, Typeof, 0> {
+                TypeofQuery {
                     client,
                     params: [],
                     stmt: &mut self.0,
-                    extractor: |row| SyntaxBorrowed {
+                    extractor: |row| TypeofBorrowed {
                         trick_y: row.get(0),
                         r#async: row.get(1),
                         r#enum: row.get(2),
                     },
-                    mapper: |it| <Syntax>::from(it),
+                    mapper: |it| <Typeof>::from(it),
                 }
             }
         }

--- a/codegen_test/src/cornucopia_async.rs
+++ b/codegen_test/src/cornucopia_async.rs
@@ -554,21 +554,87 @@ pub mod types {
                 postgres_types::__to_sql_checked(self, ty, out)
             }
         }
-        #[derive(
-            serde::Serialize,
-            Debug,
-            postgres_types::ToSql,
-            postgres_types::FromSql,
-            Clone,
-            Copy,
-            PartialEq,
-            Eq,
-        )]
-        #[postgres(name = "spongebob_character")]
+        #[derive(serde::Serialize, Debug, Clone, Copy, PartialEq, Eq)]
+        #[allow(non_camel_case_types)]
         pub enum SpongebobCharacter {
             Bob,
             Patrick,
             Squidward,
+        }
+        impl<'a> postgres_types::ToSql for SpongebobCharacter {
+            fn to_sql(
+                &self,
+                ty: &postgres_types::Type,
+                buf: &mut postgres_types::private::BytesMut,
+            ) -> Result<postgres_types::IsNull, Box<dyn std::error::Error + Sync + Send>>
+            {
+                let s = match *self {
+                    SpongebobCharacter::Bob => "Bob",
+                    SpongebobCharacter::Patrick => "Patrick",
+                    SpongebobCharacter::Squidward => "Squidward",
+                };
+                buf.extend_from_slice(s.as_bytes());
+                std::result::Result::Ok(postgres_types::IsNull::No)
+            }
+            fn accepts(ty: &postgres_types::Type) -> bool {
+                if ty.name() != "spongebob_character" {
+                    return false;
+                }
+                match *ty.kind() {
+                    postgres_types::Kind::Enum(ref variants) => {
+                        if variants.len() != 3usize {
+                            return false;
+                        }
+                        variants.iter().all(|v| match &**v {
+                            "Bob" => true,
+                            "Patrick" => true,
+                            "Squidward" => true,
+                            _ => false,
+                        })
+                    }
+                    _ => false,
+                }
+            }
+            fn to_sql_checked(
+                &self,
+                ty: &postgres_types::Type,
+                out: &mut postgres_types::private::BytesMut,
+            ) -> Result<postgres_types::IsNull, Box<dyn std::error::Error + Sync + Send>>
+            {
+                postgres_types::__to_sql_checked(self, ty, out)
+            }
+        }
+        impl<'a> postgres_types::FromSql<'a> for SpongebobCharacter {
+            fn from_sql(
+                ty: &postgres_types::Type,
+                buf: &'a [u8],
+            ) -> Result<SpongebobCharacter, Box<dyn std::error::Error + Sync + Send>> {
+                match std::str::from_utf8(buf)? {
+                    "Bob" => Ok(SpongebobCharacter::Bob),
+                    "Patrick" => Ok(SpongebobCharacter::Patrick),
+                    "Squidward" => Ok(SpongebobCharacter::Squidward),
+                    s => Result::Err(Into::into(format!("invalid variant `{}`", s))),
+                }
+            }
+            fn accepts(ty: &postgres_types::Type) -> bool {
+                if ty.name() != "spongebob_character" {
+                    return false;
+                }
+                match *ty.kind() {
+                    postgres_types::Kind::Enum(ref variants) => {
+                        if variants.len() != 3usize {
+                            return false;
+                        }
+                        variants.iter().all(|v| match &**v {
+                            "Bob" => true,
+                            "Patrick" => true,
+                            "Squidward" => true,
+                            _ => false,
+                        })
+                    }
+                    _ => false,
+                }
+            }
         }
         #[derive(serde::Serialize, Debug, postgres_types::FromSql, Clone, PartialEq)]
         #[postgres(name = "custom_composite")]
@@ -836,6 +902,149 @@ pub mod types {
             ) -> Result<postgres_types::IsNull, Box<dyn std::error::Error + Sync + Send>>
             {
                 postgres_types::__to_sql_checked(self, ty, out)
+            }
+        }
+        #[derive(serde::Serialize, Debug, postgres_types::FromSql, Copy, Clone, PartialEq)]
+        #[postgres(name = "syntax_composite")]
+        pub struct SyntaxComposite {
+            pub r#async: i32,
+        }
+        impl<'a> postgres_types::ToSql for SyntaxComposite {
+            fn to_sql(
+                &self,
+                ty: &postgres_types::Type,
+                out: &mut postgres_types::private::BytesMut,
+            ) -> Result<postgres_types::IsNull, Box<dyn std::error::Error + Sync + Send>>
+            {
+                let SyntaxComposite { r#async } = self;
+                let fields = match *ty.kind() {
+                    postgres_types::Kind::Composite(ref fields) => fields,
+                    _ => unreachable!(),
+                };
+                out.extend_from_slice(&(fields.len() as i32).to_be_bytes());
+                for field in fields {
+                    out.extend_from_slice(&field.type_().oid().to_be_bytes());
+                    let base = out.len();
+                    out.extend_from_slice(&[0; 4]);
+                    let r = match field.name() {
+                        "async" => postgres_types::ToSql::to_sql(r#async, field.type_(), out),
+                        _ => unreachable!(),
+                    };
+                    let count = match r? {
+                        postgres_types::IsNull::Yes => -1,
+                        postgres_types::IsNull::No => {
+                            let len = out.len() - base - 4;
+                            if len > i32::max_value() as usize {
+                                return Err(Into::into("value too large to transmit"));
+                            }
+                            len as i32
+                        }
+                    };
+                    out[base..base + 4].copy_from_slice(&count.to_be_bytes());
+                }
+                Ok(postgres_types::IsNull::No)
+            }
+            fn accepts(ty: &postgres_types::Type) -> bool {
+                if ty.name() != "syntax_composite" {
+                    return false;
+                }
+                match *ty.kind() {
+                    postgres_types::Kind::Composite(ref fields) => {
+                        if fields.len() != 1usize {
+                            return false;
+                        }
+                        fields.iter().all(|f| match f.name() {
+                            "async" => <i32 as postgres_types::ToSql>::accepts(f.type_()),
+                            _ => false,
+                        })
+                    }
+                    _ => false,
+                }
+            }
+            fn to_sql_checked(
+                &self,
+                ty: &postgres_types::Type,
+                out: &mut postgres_types::private::BytesMut,
+            ) -> Result<postgres_types::IsNull, Box<dyn std::error::Error + Sync + Send>>
+            {
+                postgres_types::__to_sql_checked(self, ty, out)
+            }
+        }
+        #[derive(serde::Serialize, Debug, Clone, Copy, PartialEq, Eq)]
+        #[allow(non_camel_case_types)]
+        pub enum SyntaxEnum {
+            r#async,
+            r#box,
+        }
+        impl<'a> postgres_types::ToSql for SyntaxEnum {
+            fn to_sql(
+                &self,
+                ty: &postgres_types::Type,
+                buf: &mut postgres_types::private::BytesMut,
+            ) -> Result<postgres_types::IsNull, Box<dyn std::error::Error + Sync + Send>>
+            {
+                let s = match *self {
+                    SyntaxEnum::r#async => "async",
+                    SyntaxEnum::r#box => "box",
+                };
+                buf.extend_from_slice(s.as_bytes());
+                std::result::Result::Ok(postgres_types::IsNull::No)
+            }
+            fn accepts(ty: &postgres_types::Type) -> bool {
+                if ty.name() != "syntax_enum" {
+                    return false;
+                }
+                match *ty.kind() {
+                    postgres_types::Kind::Enum(ref variants) => {
+                        if variants.len() != 2usize {
+                            return false;
+                        }
+                        variants.iter().all(|v| match &**v {
+                            "async" => true,
+                            "box" => true,
+                            _ => false,
+                        })
+                    }
+                    _ => false,
+                }
+            }
+            fn to_sql_checked(
+                &self,
+                ty: &postgres_types::Type,
+                out: &mut postgres_types::private::BytesMut,
+            ) -> Result<postgres_types::IsNull, Box<dyn std::error::Error + Sync + Send>>
+            {
+                postgres_types::__to_sql_checked(self, ty, out)
+            }
+        }
+        impl<'a> postgres_types::FromSql<'a> for SyntaxEnum {
+            fn from_sql(
+                ty: &postgres_types::Type,
+                buf: &'a [u8],
+            ) -> Result<SyntaxEnum, Box<dyn std::error::Error + Sync + Send>> {
+                match std::str::from_utf8(buf)? {
+                    "async" => Ok(SyntaxEnum::r#async),
+                    "box" => Ok(SyntaxEnum::r#box),
+                    s => Result::Err(Into::into(format!("invalid variant `{}`", s))),
+                }
+            }
+            fn accepts(ty: &postgres_types::Type) -> bool {
+                if ty.name() != "syntax_enum" {
+                    return false;
+                }
+                match *ty.kind() {
+                    postgres_types::Kind::Enum(ref variants) => {
+                        if variants.len() != 2usize {
+                            return false;
+                        }
+                        variants.iter().all(|v| match &**v {
+                            "async" => true,
+                            "box" => true,
+                            _ => false,
+                        })
+                    }
+                    _ => false,
+                }
             }
         }
     }
@@ -3972,7 +4181,56 @@ pub mod queries {
             pub name: T1,
             pub price: f64,
         }
-
+        #[derive(Clone, Copy, Debug)]
+        pub struct TrickySqlParams {
+            pub r#async: super::super::types::public::SyntaxComposite,
+            pub r#enum: super::super::types::public::SyntaxEnum,
+        }
+        #[derive(Clone, Copy, Debug)]
+        pub struct TrickySql1Params {
+            pub r#async: super::super::types::public::SyntaxComposite,
+            pub r#enum: super::super::types::public::SyntaxEnum,
+        }
+        #[derive(Clone, Copy, Debug)]
+        pub struct TrickySql2Params {
+            pub r#async: super::super::types::public::SyntaxComposite,
+            pub r#enum: super::super::types::public::SyntaxEnum,
+        }
+        #[derive(Clone, Copy, Debug)]
+        pub struct TrickySql3Params {
+            pub r#async: super::super::types::public::SyntaxComposite,
+            pub r#enum: super::super::types::public::SyntaxEnum,
+        }
+        #[derive(Clone, Copy, Debug)]
+        pub struct TrickySql4Params {
+            pub r#async: super::super::types::public::SyntaxComposite,
+            pub r#enum: super::super::types::public::SyntaxEnum,
+        }
+        #[derive(Clone, Copy, Debug)]
+        pub struct TrickySql6Params {
+            pub r#async: super::super::types::public::SyntaxComposite,
+            pub r#enum: super::super::types::public::SyntaxEnum,
+        }
+        #[derive(Clone, Copy, Debug)]
+        pub struct TrickySql7Params {
+            pub r#async: super::super::types::public::SyntaxComposite,
+            pub r#enum: super::super::types::public::SyntaxEnum,
+        }
+        #[derive(Clone, Copy, Debug)]
+        pub struct TrickySql8Params {
+            pub r#async: super::super::types::public::SyntaxComposite,
+            pub r#enum: super::super::types::public::SyntaxEnum,
+        }
+        #[derive(Clone, Copy, Debug)]
+        pub struct TrickySql9Params {
+            pub r#async: super::super::types::public::SyntaxComposite,
+            pub r#enum: super::super::types::public::SyntaxEnum,
+        }
+        #[derive(Clone, Copy, Debug)]
+        pub struct TrickySql10Params {
+            pub r#async: super::super::types::public::SyntaxComposite,
+            pub r#enum: super::super::types::public::SyntaxEnum,
+        }
         pub struct SuperSuperTypesPublicCloneCompositeQuery<'a, C: GenericClient, T, const N: usize> {
             client: &'a C,
             params: [&'a (dyn postgres_types::ToSql + Sync); N],
@@ -4213,17 +4471,26 @@ pub mod queries {
         #[derive(serde::Serialize, Debug, Clone, PartialEq)]
         pub struct Syntax {
             pub trick_y: String,
-            pub price: f64,
+            pub r#async: super::super::types::public::SyntaxComposite,
+            pub r#enum: super::super::types::public::SyntaxEnum,
         }
         pub struct SyntaxBorrowed<'a> {
             pub trick_y: &'a str,
-            pub price: f64,
+            pub r#async: super::super::types::public::SyntaxComposite,
+            pub r#enum: super::super::types::public::SyntaxEnum,
         }
         impl<'a> From<SyntaxBorrowed<'a>> for Syntax {
-            fn from(SyntaxBorrowed { trick_y, price }: SyntaxBorrowed<'a>) -> Self {
+            fn from(
+                SyntaxBorrowed {
+                    trick_y,
+                    r#async,
+                    r#enum,
+                }: SyntaxBorrowed<'a>,
+            ) -> Self {
                 Self {
                     trick_y: trick_y.into(),
-                    price,
+                    r#async,
+                    r#enum,
                 }
             }
         }
@@ -4476,151 +4743,405 @@ pub mod queries {
             }
         }
         pub fn tricky_sql() -> TrickySqlStmt {
-            TrickySqlStmt(cornucopia_async::private::Stmt::new(
-                "INSERT INTO syntax (\"trick:y\", price) VALUES ('this is not a bind_param\', $1)",
-            ))
+            TrickySqlStmt(cornucopia_async::private::Stmt::new("INSERT INTO syntax (\"trick:y\", async, enum) VALUES ('this is not a bind_param\', $1, $2)"))
         }
         pub struct TrickySqlStmt(cornucopia_async::private::Stmt);
         impl TrickySqlStmt {
             pub async fn bind<'a, C: GenericClient>(
                 &'a mut self,
                 client: &'a C,
-                price: &'a f64,
+                r#async: &'a super::super::types::public::SyntaxComposite,
+                r#enum: &'a super::super::types::public::SyntaxEnum,
             ) -> Result<u64, tokio_postgres::Error> {
                 let stmt = self.0.prepare(client).await?;
-                client.execute(stmt, &[price]).await
+                client.execute(stmt, &[r#async, r#enum]).await
             }
         }
+        impl<'a, C: GenericClient + Send + Sync>
+            cornucopia_async::Params<
+                'a,
+                TrickySqlParams,
+                std::pin::Pin<
+                    Box<
+                        dyn futures::Future<Output = Result<u64, tokio_postgres::Error>>
+                            + Send
+                            + 'a,
+                    >,
+                >,
+                C,
+            > for TrickySqlStmt
+        {
+            fn params(
+                &'a mut self,
+                client: &'a C,
+                params: &'a TrickySqlParams,
+            ) -> std::pin::Pin<
+                Box<dyn futures::Future<Output = Result<u64, tokio_postgres::Error>> + Send + 'a>,
+            > {
+                Box::pin(self.bind(client, &params.r#async, &params.r#enum))
+            }
+        }
+
         pub fn tricky_sql1() -> TrickySql1Stmt {
-            TrickySql1Stmt(cornucopia_async::private::Stmt::new(
-                "INSERT INTO syntax (\"trick:y\", price) VALUES ('this is not a :bind_param', $1)",
-            ))
+            TrickySql1Stmt(cornucopia_async::private::Stmt::new("INSERT INTO syntax (\"trick:y\", async, enum) VALUES ('this is not a :bind_param', $1, $2)"))
         }
         pub struct TrickySql1Stmt(cornucopia_async::private::Stmt);
         impl TrickySql1Stmt {
             pub async fn bind<'a, C: GenericClient>(
                 &'a mut self,
                 client: &'a C,
-                price: &'a f64,
+                r#async: &'a super::super::types::public::SyntaxComposite,
+                r#enum: &'a super::super::types::public::SyntaxEnum,
             ) -> Result<u64, tokio_postgres::Error> {
                 let stmt = self.0.prepare(client).await?;
-                client.execute(stmt, &[price]).await
+                client.execute(stmt, &[r#async, r#enum]).await
             }
         }
+        impl<'a, C: GenericClient + Send + Sync>
+            cornucopia_async::Params<
+                'a,
+                TrickySql1Params,
+                std::pin::Pin<
+                    Box<
+                        dyn futures::Future<Output = Result<u64, tokio_postgres::Error>>
+                            + Send
+                            + 'a,
+                    >,
+                >,
+                C,
+            > for TrickySql1Stmt
+        {
+            fn params(
+                &'a mut self,
+                client: &'a C,
+                params: &'a TrickySql1Params,
+            ) -> std::pin::Pin<
+                Box<dyn futures::Future<Output = Result<u64, tokio_postgres::Error>> + Send + 'a>,
+            > {
+                Box::pin(self.bind(client, &params.r#async, &params.r#enum))
+            }
+        }
+
         pub fn tricky_sql2() -> TrickySql2Stmt {
-            TrickySql2Stmt(cornucopia_async::private::Stmt::new("INSERT INTO syntax (\"trick:y\", price) VALUES ('this is not a '':bind_param''', $1)"))
+            TrickySql2Stmt(cornucopia_async::private::Stmt::new("INSERT INTO syntax (\"trick:y\", async, enum) VALUES ('this is not a '':bind_param''', $1, $2)"))
         }
         pub struct TrickySql2Stmt(cornucopia_async::private::Stmt);
         impl TrickySql2Stmt {
             pub async fn bind<'a, C: GenericClient>(
                 &'a mut self,
                 client: &'a C,
-                price: &'a f64,
+                r#async: &'a super::super::types::public::SyntaxComposite,
+                r#enum: &'a super::super::types::public::SyntaxEnum,
             ) -> Result<u64, tokio_postgres::Error> {
                 let stmt = self.0.prepare(client).await?;
-                client.execute(stmt, &[price]).await
+                client.execute(stmt, &[r#async, r#enum]).await
             }
         }
+        impl<'a, C: GenericClient + Send + Sync>
+            cornucopia_async::Params<
+                'a,
+                TrickySql2Params,
+                std::pin::Pin<
+                    Box<
+                        dyn futures::Future<Output = Result<u64, tokio_postgres::Error>>
+                            + Send
+                            + 'a,
+                    >,
+                >,
+                C,
+            > for TrickySql2Stmt
+        {
+            fn params(
+                &'a mut self,
+                client: &'a C,
+                params: &'a TrickySql2Params,
+            ) -> std::pin::Pin<
+                Box<dyn futures::Future<Output = Result<u64, tokio_postgres::Error>> + Send + 'a>,
+            > {
+                Box::pin(self.bind(client, &params.r#async, &params.r#enum))
+            }
+        }
+
         pub fn tricky_sql3() -> TrickySql3Stmt {
-            TrickySql3Stmt(cornucopia_async::private::Stmt::new("INSERT INTO syntax (\"trick:y\", price)  VALUES ($$this is not a :bind_param$$, $1)"))
+            TrickySql3Stmt(cornucopia_async::private::Stmt::new("INSERT INTO syntax (\"trick:y\", async, enum)  VALUES ($$this is not a :bind_param$$, $1, $2)"))
         }
         pub struct TrickySql3Stmt(cornucopia_async::private::Stmt);
         impl TrickySql3Stmt {
             pub async fn bind<'a, C: GenericClient>(
                 &'a mut self,
                 client: &'a C,
-                price: &'a f64,
+                r#async: &'a super::super::types::public::SyntaxComposite,
+                r#enum: &'a super::super::types::public::SyntaxEnum,
             ) -> Result<u64, tokio_postgres::Error> {
                 let stmt = self.0.prepare(client).await?;
-                client.execute(stmt, &[price]).await
+                client.execute(stmt, &[r#async, r#enum]).await
             }
         }
+        impl<'a, C: GenericClient + Send + Sync>
+            cornucopia_async::Params<
+                'a,
+                TrickySql3Params,
+                std::pin::Pin<
+                    Box<
+                        dyn futures::Future<Output = Result<u64, tokio_postgres::Error>>
+                            + Send
+                            + 'a,
+                    >,
+                >,
+                C,
+            > for TrickySql3Stmt
+        {
+            fn params(
+                &'a mut self,
+                client: &'a C,
+                params: &'a TrickySql3Params,
+            ) -> std::pin::Pin<
+                Box<dyn futures::Future<Output = Result<u64, tokio_postgres::Error>> + Send + 'a>,
+            > {
+                Box::pin(self.bind(client, &params.r#async, &params.r#enum))
+            }
+        }
+
         pub fn tricky_sql4() -> TrickySql4Stmt {
-            TrickySql4Stmt(cornucopia_async::private::Stmt::new("INSERT INTO syntax (\"trick:y\", price) VALUES ($tag$this is not a :bind_param$tag$, $1)"))
+            TrickySql4Stmt(cornucopia_async::private::Stmt::new("INSERT INTO syntax (\"trick:y\", async, enum) VALUES ($tag$this is not a :bind_param$tag$, $1, $2)"))
         }
         pub struct TrickySql4Stmt(cornucopia_async::private::Stmt);
         impl TrickySql4Stmt {
             pub async fn bind<'a, C: GenericClient>(
                 &'a mut self,
                 client: &'a C,
-                price: &'a f64,
+                r#async: &'a super::super::types::public::SyntaxComposite,
+                r#enum: &'a super::super::types::public::SyntaxEnum,
             ) -> Result<u64, tokio_postgres::Error> {
                 let stmt = self.0.prepare(client).await?;
-                client.execute(stmt, &[price]).await
+                client.execute(stmt, &[r#async, r#enum]).await
             }
         }
+        impl<'a, C: GenericClient + Send + Sync>
+            cornucopia_async::Params<
+                'a,
+                TrickySql4Params,
+                std::pin::Pin<
+                    Box<
+                        dyn futures::Future<Output = Result<u64, tokio_postgres::Error>>
+                            + Send
+                            + 'a,
+                    >,
+                >,
+                C,
+            > for TrickySql4Stmt
+        {
+            fn params(
+                &'a mut self,
+                client: &'a C,
+                params: &'a TrickySql4Params,
+            ) -> std::pin::Pin<
+                Box<dyn futures::Future<Output = Result<u64, tokio_postgres::Error>> + Send + 'a>,
+            > {
+                Box::pin(self.bind(client, &params.r#async, &params.r#enum))
+            }
+        }
+
         pub fn tricky_sql6() -> TrickySql6Stmt {
-            TrickySql6Stmt(cornucopia_async::private::Stmt::new("INSERT INTO syntax (\"trick:y\", price) VALUES (e'this is not a '':bind_param''', $1)"))
+            TrickySql6Stmt(cornucopia_async::private::Stmt::new("INSERT INTO syntax (\"trick:y\", async, enum) VALUES (e'this is not a '':bind_param''', $1, $2)"))
         }
         pub struct TrickySql6Stmt(cornucopia_async::private::Stmt);
         impl TrickySql6Stmt {
             pub async fn bind<'a, C: GenericClient>(
                 &'a mut self,
                 client: &'a C,
-                price: &'a f64,
+                r#async: &'a super::super::types::public::SyntaxComposite,
+                r#enum: &'a super::super::types::public::SyntaxEnum,
             ) -> Result<u64, tokio_postgres::Error> {
                 let stmt = self.0.prepare(client).await?;
-                client.execute(stmt, &[price]).await
+                client.execute(stmt, &[r#async, r#enum]).await
             }
         }
+        impl<'a, C: GenericClient + Send + Sync>
+            cornucopia_async::Params<
+                'a,
+                TrickySql6Params,
+                std::pin::Pin<
+                    Box<
+                        dyn futures::Future<Output = Result<u64, tokio_postgres::Error>>
+                            + Send
+                            + 'a,
+                    >,
+                >,
+                C,
+            > for TrickySql6Stmt
+        {
+            fn params(
+                &'a mut self,
+                client: &'a C,
+                params: &'a TrickySql6Params,
+            ) -> std::pin::Pin<
+                Box<dyn futures::Future<Output = Result<u64, tokio_postgres::Error>> + Send + 'a>,
+            > {
+                Box::pin(self.bind(client, &params.r#async, &params.r#enum))
+            }
+        }
+
         pub fn tricky_sql7() -> TrickySql7Stmt {
-            TrickySql7Stmt(cornucopia_async::private::Stmt::new("INSERT INTO syntax (\"trick:y\", price) VALUES (E'this is not a \':bind_param\'', $1)"))
+            TrickySql7Stmt(cornucopia_async::private::Stmt::new("INSERT INTO syntax (\"trick:y\", async, enum) VALUES (E'this is not a \':bind_param\'', $1, $2)"))
         }
         pub struct TrickySql7Stmt(cornucopia_async::private::Stmt);
         impl TrickySql7Stmt {
             pub async fn bind<'a, C: GenericClient>(
                 &'a mut self,
                 client: &'a C,
-                price: &'a f64,
+                r#async: &'a super::super::types::public::SyntaxComposite,
+                r#enum: &'a super::super::types::public::SyntaxEnum,
             ) -> Result<u64, tokio_postgres::Error> {
                 let stmt = self.0.prepare(client).await?;
-                client.execute(stmt, &[price]).await
+                client.execute(stmt, &[r#async, r#enum]).await
             }
         }
+        impl<'a, C: GenericClient + Send + Sync>
+            cornucopia_async::Params<
+                'a,
+                TrickySql7Params,
+                std::pin::Pin<
+                    Box<
+                        dyn futures::Future<Output = Result<u64, tokio_postgres::Error>>
+                            + Send
+                            + 'a,
+                    >,
+                >,
+                C,
+            > for TrickySql7Stmt
+        {
+            fn params(
+                &'a mut self,
+                client: &'a C,
+                params: &'a TrickySql7Params,
+            ) -> std::pin::Pin<
+                Box<dyn futures::Future<Output = Result<u64, tokio_postgres::Error>> + Send + 'a>,
+            > {
+                Box::pin(self.bind(client, &params.r#async, &params.r#enum))
+            }
+        }
+
         pub fn tricky_sql8() -> TrickySql8Stmt {
-            TrickySql8Stmt(cornucopia_async::private::Stmt::new("INSERT INTO syntax (\"trick:y\", price) VALUES (e'this is ''not'' a \':bind_param\'', $1)"))
+            TrickySql8Stmt(cornucopia_async::private::Stmt::new("INSERT INTO syntax (\"trick:y\", async, enum) VALUES (e'this is ''not'' a \':bind_param\'', $1, $2)"))
         }
         pub struct TrickySql8Stmt(cornucopia_async::private::Stmt);
         impl TrickySql8Stmt {
             pub async fn bind<'a, C: GenericClient>(
                 &'a mut self,
                 client: &'a C,
-                price: &'a f64,
+                r#async: &'a super::super::types::public::SyntaxComposite,
+                r#enum: &'a super::super::types::public::SyntaxEnum,
             ) -> Result<u64, tokio_postgres::Error> {
                 let stmt = self.0.prepare(client).await?;
-                client.execute(stmt, &[price]).await
+                client.execute(stmt, &[r#async, r#enum]).await
             }
         }
+        impl<'a, C: GenericClient + Send + Sync>
+            cornucopia_async::Params<
+                'a,
+                TrickySql8Params,
+                std::pin::Pin<
+                    Box<
+                        dyn futures::Future<Output = Result<u64, tokio_postgres::Error>>
+                            + Send
+                            + 'a,
+                    >,
+                >,
+                C,
+            > for TrickySql8Stmt
+        {
+            fn params(
+                &'a mut self,
+                client: &'a C,
+                params: &'a TrickySql8Params,
+            ) -> std::pin::Pin<
+                Box<dyn futures::Future<Output = Result<u64, tokio_postgres::Error>> + Send + 'a>,
+            > {
+                Box::pin(self.bind(client, &params.r#async, &params.r#enum))
+            }
+        }
+
         pub fn tricky_sql9() -> TrickySql9Stmt {
-            TrickySql9Stmt(cornucopia_async::private::Stmt::new("INSERT INTO syntax (\"trick:y\", price) VALUES (E'this is \'not\' a \':bind_param\'', $1)"))
+            TrickySql9Stmt(cornucopia_async::private::Stmt::new("INSERT INTO syntax (\"trick:y\", async, enum) VALUES (E'this is \'not\' a \':bind_param\'', $1, $2)"))
         }
         pub struct TrickySql9Stmt(cornucopia_async::private::Stmt);
         impl TrickySql9Stmt {
             pub async fn bind<'a, C: GenericClient>(
                 &'a mut self,
                 client: &'a C,
-                price: &'a f64,
+                r#async: &'a super::super::types::public::SyntaxComposite,
+                r#enum: &'a super::super::types::public::SyntaxEnum,
             ) -> Result<u64, tokio_postgres::Error> {
                 let stmt = self.0.prepare(client).await?;
-                client.execute(stmt, &[price]).await
+                client.execute(stmt, &[r#async, r#enum]).await
             }
         }
+        impl<'a, C: GenericClient + Send + Sync>
+            cornucopia_async::Params<
+                'a,
+                TrickySql9Params,
+                std::pin::Pin<
+                    Box<
+                        dyn futures::Future<Output = Result<u64, tokio_postgres::Error>>
+                            + Send
+                            + 'a,
+                    >,
+                >,
+                C,
+            > for TrickySql9Stmt
+        {
+            fn params(
+                &'a mut self,
+                client: &'a C,
+                params: &'a TrickySql9Params,
+            ) -> std::pin::Pin<
+                Box<dyn futures::Future<Output = Result<u64, tokio_postgres::Error>> + Send + 'a>,
+            > {
+                Box::pin(self.bind(client, &params.r#async, &params.r#enum))
+            }
+        }
+
         pub fn tricky_sql10() -> TrickySql10Stmt {
-            TrickySql10Stmt(cornucopia_async::private::Stmt::new(
-                "INSERT INTO syntax (\"trick:y\", price) VALUES ('this is just a cast'::text, $1)",
-            ))
+            TrickySql10Stmt(cornucopia_async::private::Stmt::new("INSERT INTO syntax (\"trick:y\", async, enum) VALUES ('this is just a cast'::text, $1, $2)"))
         }
         pub struct TrickySql10Stmt(cornucopia_async::private::Stmt);
         impl TrickySql10Stmt {
             pub async fn bind<'a, C: GenericClient>(
                 &'a mut self,
                 client: &'a C,
-                price: &'a f64,
+                r#async: &'a super::super::types::public::SyntaxComposite,
+                r#enum: &'a super::super::types::public::SyntaxEnum,
             ) -> Result<u64, tokio_postgres::Error> {
                 let stmt = self.0.prepare(client).await?;
-                client.execute(stmt, &[price]).await
+                client.execute(stmt, &[r#async, r#enum]).await
             }
         }
+        impl<'a, C: GenericClient + Send + Sync>
+            cornucopia_async::Params<
+                'a,
+                TrickySql10Params,
+                std::pin::Pin<
+                    Box<
+                        dyn futures::Future<Output = Result<u64, tokio_postgres::Error>>
+                            + Send
+                            + 'a,
+                    >,
+                >,
+                C,
+            > for TrickySql10Stmt
+        {
+            fn params(
+                &'a mut self,
+                client: &'a C,
+                params: &'a TrickySql10Params,
+            ) -> std::pin::Pin<
+                Box<dyn futures::Future<Output = Result<u64, tokio_postgres::Error>> + Send + 'a>,
+            > {
+                Box::pin(self.bind(client, &params.r#async, &params.r#enum))
+            }
+        }
+
         pub fn syntax() -> SyntaxStmt {
             SyntaxStmt(cornucopia_async::private::Stmt::new("SELECT * FROM syntax"))
         }
@@ -4636,7 +5157,8 @@ pub mod queries {
                     stmt: &mut self.0,
                     extractor: |row| SyntaxBorrowed {
                         trick_y: row.get(0),
-                        price: row.get(1),
+                        r#async: row.get(1),
+                        r#enum: row.get(2),
                     },
                     mapper: |it| <Syntax>::from(it),
                 }

--- a/codegen_test/src/cornucopia_sync.rs
+++ b/codegen_test/src/cornucopia_sync.rs
@@ -4294,23 +4294,23 @@ pub mod queries {
             }
         }
         #[derive(serde::Serialize, Debug, Clone, PartialEq)]
-        pub struct Syntax {
+        pub struct Typeof {
             pub trick_y: String,
             pub r#async: super::super::types::public::SyntaxComposite,
             pub r#enum: super::super::types::public::SyntaxEnum,
         }
-        pub struct SyntaxBorrowed<'a> {
+        pub struct TypeofBorrowed<'a> {
             pub trick_y: &'a str,
             pub r#async: super::super::types::public::SyntaxComposite,
             pub r#enum: super::super::types::public::SyntaxEnum,
         }
-        impl<'a> From<SyntaxBorrowed<'a>> for Syntax {
+        impl<'a> From<TypeofBorrowed<'a>> for Typeof {
             fn from(
-                SyntaxBorrowed {
+                TypeofBorrowed {
                     trick_y,
                     r#async,
                     r#enum,
-                }: SyntaxBorrowed<'a>,
+                }: TypeofBorrowed<'a>,
             ) -> Self {
                 Self {
                     trick_y: trick_y.into(),
@@ -4319,19 +4319,19 @@ pub mod queries {
                 }
             }
         }
-        pub struct SyntaxQuery<'a, C: GenericClient, T, const N: usize> {
+        pub struct TypeofQuery<'a, C: GenericClient, T, const N: usize> {
             client: &'a mut C,
             params: [&'a (dyn postgres_types::ToSql + Sync); N],
             stmt: &'a mut cornucopia_sync::private::Stmt,
-            extractor: fn(&postgres::Row) -> SyntaxBorrowed,
-            mapper: fn(SyntaxBorrowed) -> T,
+            extractor: fn(&postgres::Row) -> TypeofBorrowed,
+            mapper: fn(TypeofBorrowed) -> T,
         }
-        impl<'a, C, T: 'a, const N: usize> SyntaxQuery<'a, C, T, N>
+        impl<'a, C, T: 'a, const N: usize> TypeofQuery<'a, C, T, N>
         where
             C: GenericClient,
         {
-            pub fn map<R>(self, mapper: fn(SyntaxBorrowed) -> R) -> SyntaxQuery<'a, C, R, N> {
-                SyntaxQuery {
+            pub fn map<R>(self, mapper: fn(TypeofBorrowed) -> R) -> TypeofQuery<'a, C, R, N> {
+                TypeofQuery {
                     client: self.client,
                     params: self.params,
                     stmt: self.stmt,
@@ -4843,25 +4843,25 @@ pub mod queries {
             }
         }
 
-        pub fn syntax() -> SyntaxStmt {
-            SyntaxStmt(cornucopia_sync::private::Stmt::new("SELECT * FROM syntax"))
+        pub fn r#typeof() -> TypeofStmt {
+            TypeofStmt(cornucopia_sync::private::Stmt::new("SELECT * FROM syntax"))
         }
-        pub struct SyntaxStmt(cornucopia_sync::private::Stmt);
-        impl SyntaxStmt {
+        pub struct TypeofStmt(cornucopia_sync::private::Stmt);
+        impl TypeofStmt {
             pub fn bind<'a, C: GenericClient>(
                 &'a mut self,
                 client: &'a mut C,
-            ) -> SyntaxQuery<'a, C, Syntax, 0> {
-                SyntaxQuery {
+            ) -> TypeofQuery<'a, C, Typeof, 0> {
+                TypeofQuery {
                     client,
                     params: [],
                     stmt: &mut self.0,
-                    extractor: |row| SyntaxBorrowed {
+                    extractor: |row| TypeofBorrowed {
                         trick_y: row.get(0),
                         r#async: row.get(1),
                         r#enum: row.get(2),
                     },
-                    mapper: |it| <Syntax>::from(it),
+                    mapper: |it| <Typeof>::from(it),
                 }
             }
         }

--- a/codegen_test/src/main.rs
+++ b/codegen_test/src/main.rs
@@ -33,7 +33,7 @@ use crate::cornucopia_sync::{
             select_everything_array, select_nightmare, Everything, EverythingArray,
             EverythingArrayParams, EverythingParams,
         },
-        syntax::{syntax, tricky_sql10, TrickySql10Params},
+        syntax::{r#typeof, tricky_sql10, TrickySql10Params},
     },
     types::public::{
         CloneCompositeBorrowed, CopyComposite, CustomComposite, CustomCompositeBorrowed,
@@ -523,5 +523,5 @@ pub fn test_keyword_escaping(client: &mut Client) {
         r#enum: SyntaxEnum::r#box,
     };
     tricky_sql10().params(client, &params).unwrap();
-    syntax().bind(client).all().unwrap();
+    r#typeof().bind(client).all().unwrap();
 }

--- a/codegen_test/src/main.rs
+++ b/codegen_test/src/main.rs
@@ -33,12 +33,13 @@ use crate::cornucopia_sync::{
             select_everything_array, select_nightmare, Everything, EverythingArray,
             EverythingArrayParams, EverythingParams,
         },
+        syntax::{syntax, tricky_sql10, TrickySql10Params},
     },
     types::public::{
         CloneCompositeBorrowed, CopyComposite, CustomComposite, CustomCompositeBorrowed,
         DomainComposite, DomainCompositeParams, NamedComposite, NamedCompositeBorrowed,
         NightmareComposite, NightmareCompositeParams, NullityComposite, NullityCompositeParams,
-        SpongebobCharacter,
+        SpongebobCharacter, SyntaxComposite, SyntaxEnum,
     },
 };
 use ::cornucopia_sync::Params;
@@ -59,6 +60,7 @@ pub fn main() {
     test_stress(client);
     test_domain(client);
     test_trait_sql(client);
+    test_keyword_escaping(client);
 }
 
 pub fn moving<T>(_item: T) {}
@@ -512,4 +514,14 @@ pub fn test_stress(client: &mut Client) {
     assert_eq!(1, insert_nightmare().bind(client, &params).unwrap());
     let actual = select_nightmare().bind(client).one().unwrap();
     assert_eq!(expected, actual);
+}
+
+// Test keyword escaping
+pub fn test_keyword_escaping(client: &mut Client) {
+    let params = TrickySql10Params {
+        r#async: SyntaxComposite { r#async: 34 },
+        r#enum: SyntaxEnum::r#box,
+    };
+    tricky_sql10().params(client, &params).unwrap();
+    syntax().bind(client).all().unwrap();
 }

--- a/cornucopia/src/codegen.rs
+++ b/cornucopia/src/codegen.rs
@@ -9,7 +9,7 @@ use crate::{
         Preparation, PreparedContent, PreparedField, PreparedItem, PreparedModule, PreparedQuery,
         PreparedType,
     },
-    utils::{join_comma, join_ln, unescape_keyword},
+    utils::{escape_keyword, join_comma, join_ln, unescape_keyword},
     CodegenSettings,
 };
 
@@ -516,9 +516,10 @@ fn gen_query_fn(
     let struct_name = name.to_upper_camel_case();
     {
         let sql = sql.replace('"', "\\\""); // Rust string format escaping
+        let escaped = escape_keyword(name.clone());
         gen!(
             w,
-            "pub fn {name}() -> {struct_name}Stmt {{
+            "pub fn {escaped}() -> {struct_name}Stmt {{
                 {struct_name}Stmt(cornucopia_{client_name}::private::Stmt::new(\"{sql}\"))
             }}
             pub struct {struct_name}Stmt(cornucopia_{client_name}::private::Stmt);

--- a/cornucopia/src/codegen.rs
+++ b/cornucopia/src/codegen.rs
@@ -695,7 +695,7 @@ fn gen_custom_type(
                 #[allow(non_camel_case_types)]
                 pub enum {struct_name} {{ {variants_str} }}",
             );
-            enum_sql(w, name, struct_name, &variants);
+            enum_sql(w, name, struct_name, variants);
         }
         PreparedContent::Composite(fields) => {
             let fields_str = join_comma(fields, |w, f| {

--- a/cornucopia/src/parser.rs
+++ b/cornucopia/src/parser.rs
@@ -290,7 +290,7 @@ impl QueryDataStruct {
                     || {
                         registered_structs
                             .iter()
-                            .find_map(|it| (it.name == *named).then(|| it.fields.as_slice()))
+                            .find_map(|it| (it.name == *named).then_some(it.fields.as_slice()))
                             .unwrap_or(&[])
                     },
                     Vec::as_slice,

--- a/cornucopia/src/prepare_queries.rs
+++ b/cornucopia/src/prepare_queries.rs
@@ -39,14 +39,13 @@ impl PreparedField {
     pub(crate) fn new(
         name: String,
         ty: Rc<CornucopiaType>,
-        is_nullable: bool,
-        is_inner_nullable: bool,
+        nullity: Option<&NullableIdent>,
     ) -> Self {
         Self {
-            name: escape_keyword(name.clone()),
+            name: escape_keyword(name),
             ty,
-            is_nullable,
-            is_inner_nullable,
+            is_nullable: nullity.map_or(false, |it| it.nullable),
+            is_inner_nullable: nullity.map_or(false, |it| it.inner_nullable),
         }
     }
 }
@@ -257,8 +256,7 @@ fn prepare_type(
                         PreparedField::new(
                             field.name().to_string(),
                             registrar.ref_of(field.type_()),
-                            nullity.map_or(false, |it| it.nullable),
-                            nullity.map_or(false, |it| it.inner_nullable),
+                            nullity,
                         )
                     })
                     .collect(),
@@ -357,8 +355,7 @@ fn prepare_query(
                 registrar
                     .register(&col_name.value, &col_ty, &name, module_info)?
                     .clone(),
-                nullity.map_or(false, |it| it.nullable),
-                nullity.map_or(false, |it| it.inner_nullable),
+                nullity,
             ));
         }
         param_fields
@@ -388,8 +385,7 @@ fn prepare_query(
             row_fields.push(PreparedField::new(
                 normalize_rust_name(&col_name),
                 ty,
-                nullity.map_or(false, |it| it.nullable),
-                nullity.map_or(false, |it| it.inner_nullable),
+                nullity,
             ));
         }
         row_fields

--- a/cornucopia/src/prepare_queries.rs
+++ b/cornucopia/src/prepare_queries.rs
@@ -10,6 +10,7 @@ use crate::{
     read_queries::ModuleInfo,
     type_registrar::CornucopiaType,
     type_registrar::TypeRegistrar,
+    utils::escape_keyword,
     validation,
 };
 
@@ -32,6 +33,22 @@ pub struct PreparedField {
     pub(crate) ty: Rc<CornucopiaType>,
     pub(crate) is_nullable: bool,
     pub(crate) is_inner_nullable: bool, // Vec only
+}
+
+impl PreparedField {
+    pub(crate) fn new(
+        name: String,
+        ty: Rc<CornucopiaType>,
+        is_nullable: bool,
+        is_inner_nullable: bool,
+    ) -> Self {
+        Self {
+            name: escape_keyword(name.clone()),
+            ty,
+            is_nullable,
+            is_inner_nullable,
+        }
+    }
 }
 
 impl PreparedField {
@@ -227,19 +244,22 @@ fn prepare_type(
             .find(|it| it.name.value == pg_ty.name())
             .map_or(&[] as &[NullableIdent], |it| it.fields.as_slice());
         let content = match pg_ty.kind() {
-            Kind::Enum(variants) => PreparedContent::Enum(variants.clone()),
+            Kind::Enum(variants) => {
+                PreparedContent::Enum(variants.clone().into_iter().map(escape_keyword).collect())
+            }
+
             Kind::Domain(_) => return None,
             Kind::Composite(fields) => PreparedContent::Composite(
                 fields
                     .iter()
                     .map(|field| {
                         let nullity = declared.iter().find(|it| it.name.value == field.name());
-                        PreparedField {
-                            name: field.name().to_string(),
-                            ty: registrar.ref_of(field.type_()),
-                            is_nullable: nullity.map_or(false, |it| it.nullable),
-                            is_inner_nullable: nullity.map_or(false, |it| it.inner_nullable),
-                        }
+                        PreparedField::new(
+                            field.name().to_string(),
+                            registrar.ref_of(field.type_()),
+                            nullity.map_or(false, |it| it.nullable),
+                            nullity.map_or(false, |it| it.inner_nullable),
+                        )
                     })
                     .collect(),
             ),
@@ -332,14 +352,14 @@ fn prepare_query(
                 .iter()
                 .find(|x| x.name.value == col_name.value);
             // Register type
-            param_fields.push(PreparedField {
-                name: col_name.value.clone(),
-                ty: registrar
+            param_fields.push(PreparedField::new(
+                col_name.value.clone(),
+                registrar
                     .register(&col_name.value, &col_ty, &name, module_info)?
                     .clone(),
-                is_nullable: nullity.map_or(false, |it| it.nullable),
-                is_inner_nullable: nullity.map_or(false, |it| it.inner_nullable),
-            });
+                nullity.map_or(false, |it| it.nullable),
+                nullity.map_or(false, |it| it.inner_nullable),
+            ));
         }
         param_fields
     };
@@ -365,12 +385,12 @@ fn prepare_query(
             let ty = registrar
                 .register(&col_name, col_ty, &name, module_info)?
                 .clone();
-            row_fields.push(PreparedField {
-                name: normalize_rust_name(&col_name),
+            row_fields.push(PreparedField::new(
+                normalize_rust_name(&col_name),
                 ty,
-                is_nullable: nullity.map_or(false, |it| it.nullable),
-                is_inner_nullable: nullity.map_or(false, |it| it.inner_nullable),
-            });
+                nullity.map_or(false, |it| it.nullable),
+                nullity.map_or(false, |it| it.inner_nullable),
+            ));
         }
         row_fields
     };

--- a/cornucopia/src/utils.rs
+++ b/cornucopia/src/utils.rs
@@ -106,3 +106,26 @@ pub(crate) fn db_err(err: &postgres::Error) -> Option<(u32, String, Option<Strin
         None
     }
 }
+
+/// Sorted list of rust reserved keywords
+pub(crate) const KEYWORD: [&str; 52] = [
+    "Self", "abstract", "as", "async", "await", "become", "box", "break", "const", "continue",
+    "crate", "do", "dyn", "else", "enum", "extern", "false", "final", "fn", "for", "if", "impl",
+    "in", "let", "loop", "macro", "match", "mod", "move", "mut", "override", "priv", "pub", "ref",
+    "return", "self", "static", "struct", "super", "trait", "true", "try", "type", "typeof",
+    "union", "unsafe", "unsized", "use", "virtual", "where", "while", "yield",
+];
+
+/// Escape ident if clash with rust reserved keywords
+pub(crate) fn escape_keyword(ident: String) -> String {
+    if KEYWORD.binary_search(&ident.as_str()).is_ok() {
+        format!("r#{ident}")
+    } else {
+        ident
+    }
+}
+
+/// Unescape ident
+pub(crate) fn unescape_keyword(ident: &str) -> &str {
+    ident.trim_start_matches("r#")
+}

--- a/cornucopia/src/utils.rs
+++ b/cornucopia/src/utils.rs
@@ -107,9 +107,12 @@ pub(crate) fn db_err(err: &postgres::Error) -> Option<(u32, String, Option<Strin
     }
 }
 
+/// Sorted list of rust reserved keywords that cannot be escaped
+pub(crate) const STRICT_KEYWORD: [&str; 5] = ["Self", "_", "crate", "self", "super"];
+
 /// Sorted list of rust reserved keywords
-pub(crate) const KEYWORD: [&str; 52] = [
-    "Self", "abstract", "as", "async", "await", "become", "box", "break", "const", "continue",
+pub(crate) const KEYWORD: [&str; 53] = [
+    "Self", "_", "abstract", "as", "async", "await", "become", "box", "break", "const", "continue",
     "crate", "do", "dyn", "else", "enum", "extern", "false", "final", "fn", "for", "if", "impl",
     "in", "let", "loop", "macro", "match", "mod", "move", "mut", "override", "priv", "pub", "ref",
     "return", "self", "static", "struct", "super", "trait", "true", "try", "type", "typeof",

--- a/cornucopia/src/validation.rs
+++ b/cornucopia/src/validation.rs
@@ -206,7 +206,7 @@ pub(crate) fn named_struct_field(
     if let Some((field, prev_field)) = fields.iter().find_map(|f| {
         prev_fields
             .iter()
-            .find_map(|prev_f| (f.name == prev_f.name && f.ty != prev_f.ty).then(|| (f, prev_f)))
+            .find_map(|prev_f| (f.name == prev_f.name && f.ty != prev_f.ty).then_some((f, prev_f)))
     }) {
         return Err(Error::IncompatibleNamedType {
             src: info.into(),

--- a/examples/basic_async/src/cornucopia.rs
+++ b/examples/basic_async/src/cornucopia.rs
@@ -6,14 +6,87 @@
 #[allow(dead_code)]
 pub mod types {
     pub mod public {
-        #[derive(
-            Debug, postgres_types::ToSql, postgres_types::FromSql, Clone, Copy, PartialEq, Eq,
-        )]
-        #[postgres(name = "spongebob_character")]
+        #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+        #[allow(non_camel_case_types)]
         pub enum SpongebobCharacter {
             Bob,
             Patrick,
             Squidward,
+        }
+        impl<'a> postgres_types::ToSql for SpongebobCharacter {
+            fn to_sql(
+                &self,
+                ty: &postgres_types::Type,
+                buf: &mut postgres_types::private::BytesMut,
+            ) -> Result<postgres_types::IsNull, Box<dyn std::error::Error + Sync + Send>>
+            {
+                let s = match *self {
+                    SpongebobCharacter::Bob => "Bob",
+                    SpongebobCharacter::Patrick => "Patrick",
+                    SpongebobCharacter::Squidward => "Squidward",
+                };
+                buf.extend_from_slice(s.as_bytes());
+                std::result::Result::Ok(postgres_types::IsNull::No)
+            }
+            fn accepts(ty: &postgres_types::Type) -> bool {
+                if ty.name() != "spongebob_character" {
+                    return false;
+                }
+                match *ty.kind() {
+                    postgres_types::Kind::Enum(ref variants) => {
+                        if variants.len() != 3usize {
+                            return false;
+                        }
+                        variants.iter().all(|v| match &**v {
+                            "Bob" => true,
+                            "Patrick" => true,
+                            "Squidward" => true,
+                            _ => false,
+                        })
+                    }
+                    _ => false,
+                }
+            }
+            fn to_sql_checked(
+                &self,
+                ty: &postgres_types::Type,
+                out: &mut postgres_types::private::BytesMut,
+            ) -> Result<postgres_types::IsNull, Box<dyn std::error::Error + Sync + Send>>
+            {
+                postgres_types::__to_sql_checked(self, ty, out)
+            }
+        }
+        impl<'a> postgres_types::FromSql<'a> for SpongebobCharacter {
+            fn from_sql(
+                ty: &postgres_types::Type,
+                buf: &'a [u8],
+            ) -> Result<SpongebobCharacter, Box<dyn std::error::Error + Sync + Send>> {
+                match std::str::from_utf8(buf)? {
+                    "Bob" => Ok(SpongebobCharacter::Bob),
+                    "Patrick" => Ok(SpongebobCharacter::Patrick),
+                    "Squidward" => Ok(SpongebobCharacter::Squidward),
+                    s => Result::Err(Into::into(format!("invalid variant `{}`", s))),
+                }
+            }
+            fn accepts(ty: &postgres_types::Type) -> bool {
+                if ty.name() != "spongebob_character" {
+                    return false;
+                }
+                match *ty.kind() {
+                    postgres_types::Kind::Enum(ref variants) => {
+                        if variants.len() != 3usize {
+                            return false;
+                        }
+                        variants.iter().all(|v| match &**v {
+                            "Bob" => true,
+                            "Patrick" => true,
+                            "Squidward" => true,
+                            _ => false,
+                        })
+                    }
+                    _ => false,
+                }
+            }
         }
     }
 }

--- a/examples/basic_sync/src/cornucopia.rs
+++ b/examples/basic_sync/src/cornucopia.rs
@@ -6,14 +6,87 @@
 #[allow(dead_code)]
 pub mod types {
     pub mod public {
-        #[derive(
-            Debug, postgres_types::ToSql, postgres_types::FromSql, Clone, Copy, PartialEq, Eq,
-        )]
-        #[postgres(name = "spongebob_character")]
+        #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+        #[allow(non_camel_case_types)]
         pub enum SpongebobCharacter {
             Bob,
             Patrick,
             Squidward,
+        }
+        impl<'a> postgres_types::ToSql for SpongebobCharacter {
+            fn to_sql(
+                &self,
+                ty: &postgres_types::Type,
+                buf: &mut postgres_types::private::BytesMut,
+            ) -> Result<postgres_types::IsNull, Box<dyn std::error::Error + Sync + Send>>
+            {
+                let s = match *self {
+                    SpongebobCharacter::Bob => "Bob",
+                    SpongebobCharacter::Patrick => "Patrick",
+                    SpongebobCharacter::Squidward => "Squidward",
+                };
+                buf.extend_from_slice(s.as_bytes());
+                std::result::Result::Ok(postgres_types::IsNull::No)
+            }
+            fn accepts(ty: &postgres_types::Type) -> bool {
+                if ty.name() != "spongebob_character" {
+                    return false;
+                }
+                match *ty.kind() {
+                    postgres_types::Kind::Enum(ref variants) => {
+                        if variants.len() != 3usize {
+                            return false;
+                        }
+                        variants.iter().all(|v| match &**v {
+                            "Bob" => true,
+                            "Patrick" => true,
+                            "Squidward" => true,
+                            _ => false,
+                        })
+                    }
+                    _ => false,
+                }
+            }
+            fn to_sql_checked(
+                &self,
+                ty: &postgres_types::Type,
+                out: &mut postgres_types::private::BytesMut,
+            ) -> Result<postgres_types::IsNull, Box<dyn std::error::Error + Sync + Send>>
+            {
+                postgres_types::__to_sql_checked(self, ty, out)
+            }
+        }
+        impl<'a> postgres_types::FromSql<'a> for SpongebobCharacter {
+            fn from_sql(
+                ty: &postgres_types::Type,
+                buf: &'a [u8],
+            ) -> Result<SpongebobCharacter, Box<dyn std::error::Error + Sync + Send>> {
+                match std::str::from_utf8(buf)? {
+                    "Bob" => Ok(SpongebobCharacter::Bob),
+                    "Patrick" => Ok(SpongebobCharacter::Patrick),
+                    "Squidward" => Ok(SpongebobCharacter::Squidward),
+                    s => Result::Err(Into::into(format!("invalid variant `{}`", s))),
+                }
+            }
+            fn accepts(ty: &postgres_types::Type) -> bool {
+                if ty.name() != "spongebob_character" {
+                    return false;
+                }
+                match *ty.kind() {
+                    postgres_types::Kind::Enum(ref variants) => {
+                        if variants.len() != 3usize {
+                            return false;
+                        }
+                        variants.iter().all(|v| match &**v {
+                            "Bob" => true,
+                            "Patrick" => true,
+                            "Squidward" => true,
+                            _ => false,
+                        })
+                    }
+                    _ => false,
+                }
+            }
         }
     }
 }

--- a/integration/fixtures/errors/validation.toml
+++ b/integration/fixtures/errors/validation.toml
@@ -337,19 +337,3 @@ error = '''
  2 │ SELECT * FROM author;
    ╰────
   help: use a different name'''
-
-[[test]]
-name = 'NameReserved'
-query = '''
---! select
-SELECT id, name as trait FROM author;
-'''
-error = '''
-× `trait` is a reserved rust keyword
-   ╭─[queries/test.sql:1:1]
- 1 │ --! select
-   ·     ───┬──
-   ·        ╰── from row declared here
- 2 │ SELECT id, name as trait FROM author;
-   ╰────
-  help: use a different name'''

--- a/integration/fixtures/errors/validation.toml
+++ b/integration/fixtures/errors/validation.toml
@@ -309,15 +309,15 @@ error = '''
 [[test]]
 name = 'QueryReserved'
 query = '''
---! unsized
+--! crate
 SELECT * FROM author;
 '''
 error = '''
-× `unsized` is a reserved rust keyword
+× `crate` is a reserved rust keyword that cannot be escaped
    ╭─[queries/test.sql:1:1]
- 1 │ --! unsized
-   ·     ───┬───
-   ·        ╰── reserved rust keyword
+ 1 │ --! crate
+   ·     ──┬──
+   ·       ╰── reserved rust keyword
  2 │ SELECT * FROM author;
    ╰────
   help: use a different name'''
@@ -329,11 +329,27 @@ query = '''
 SELECT * FROM author;
 '''
 error = '''
-× `Self` is a reserved rust keyword
+× `Self` is a reserved rust keyword that cannot be escaped
    ╭─[queries/test.sql:1:1]
  1 │ --! select: Self()
    ·             ──┬─
    ·               ╰── reserved rust keyword
  2 │ SELECT * FROM author;
+   ╰────
+  help: use a different name'''
+
+[[test]]
+name = 'NameReserved'
+query = '''
+--! query
+SELECT id, name as _ FROM author;
+'''
+error = '''
+× `_` is a reserved rust keyword that cannot be escaped
+   ╭─[queries/test.sql:1:1]
+ 1 │ --! query
+   ·     ──┬──
+   ·       ╰── from row declared here
+ 2 │ SELECT id, name as _ FROM author;
    ╰────
   help: use a different name'''


### PR DESCRIPTION
Add support for rust reserved keywords everywhere we can escape them. To achieve this we have to use an even more custom implementation of `ToSql` and `FromSql` traits, and we now have to generate them for enums.

Superseeds #159 