### PR TITLE
Add optional recursive query look up

### DIFF
--- a/bench/codegen.rs
+++ b/bench/codegen.rs
@@ -16,6 +16,7 @@ fn bench(c: &mut Criterion) {
                 CodegenSettings {
                     is_async: false,
                     derive_ser: true,
+                    is_recursive: false,
                 },
             )
             .unwrap()
@@ -30,6 +31,7 @@ fn bench(c: &mut Criterion) {
                 CodegenSettings {
                     is_async: true,
                     derive_ser: true,
+                    is_recursive: false,
                 },
             )
             .unwrap()

--- a/cornucopia/src/cli.rs
+++ b/cornucopia/src/cli.rs
@@ -23,6 +23,9 @@ struct Args {
     /// Derive serde's `Serialize` trait for generated types.
     #[clap(long)]
     serialize: bool,
+    /// Recursive lookup
+    #[clap(long)]
+    recursive: bool,
 }
 
 #[derive(Debug, Subcommand)]
@@ -48,6 +51,7 @@ pub fn run() -> Result<(), Error> {
         action,
         sync,
         serialize,
+        recursive,
     } = Args::parse();
 
     match action {
@@ -60,6 +64,7 @@ pub fn run() -> Result<(), Error> {
                 CodegenSettings {
                     is_async: !sync,
                     derive_ser: serialize,
+                    is_recursive: recursive,
                 },
             )?;
         }
@@ -73,6 +78,7 @@ pub fn run() -> Result<(), Error> {
                 CodegenSettings {
                     is_async: !sync,
                     derive_ser: serialize,
+                    is_recursive: recursive,
                 },
             ) {
                 container::cleanup(podman).ok();

--- a/cornucopia/src/codegen.rs
+++ b/cornucopia/src/codegen.rs
@@ -311,6 +311,7 @@ fn gen_row_structs(
     CodegenSettings {
         is_async,
         derive_ser,
+        ..
     }: CodegenSettings,
 ) {
     let PreparedItem {
@@ -614,6 +615,7 @@ fn gen_custom_type(
     CodegenSettings {
         derive_ser,
         is_async,
+        ..
     }: CodegenSettings,
 ) {
     let PreparedType {

--- a/cornucopia/src/read_queries.rs
+++ b/cornucopia/src/read_queries.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use miette::NamedSource;
 
 use self::error::Error;
@@ -66,6 +68,76 @@ pub(crate) fn read_query_modules(dir_path: &str) -> Result<Vec<ModuleInfo>, Erro
     // Sort module for consistent codegen
     modules_info.sort_by(|a, b| a.name.cmp(&b.name));
     Ok(modules_info)
+}
+
+/// Reads queries in the directory and checks each directory found within given path.
+/// Only .sql files are considered.
+///
+/// # Error
+/// Returns an error if `dir_path` does not point to a valid directory or if a query file cannot be parsed.
+pub(crate) fn read_query_modules_recursive(dir_path: &str) -> Result<Vec<ModuleInfo>, Error> {
+    let mut modules_info = Vec::new();
+    for entry_result in std::fs::read_dir(dir_path).map_err(|err| Error {
+        err,
+        path: String::from(dir_path),
+    })? {
+        // Directory entry
+        let entry = entry_result.map_err(|err| Error {
+            err,
+            path: dir_path.to_owned(),
+        })?;
+        let path_buf = entry.path();
+
+        let path_bufs = if path_buf.is_dir() {
+            find_queries(&path_buf, Vec::<PathBuf>::new())
+        } else {
+            vec![path_buf]
+        };
+
+        // Check we're dealing with a .sql file
+        for path_buf in path_bufs {
+            if path_buf
+                .extension()
+                .map(|extension| extension == "sql")
+                .unwrap_or_default()
+            {
+                let module_name = path_buf
+                    .file_stem()
+                    .expect("is a file")
+                    .to_str()
+                    .expect("file name is valid utf8")
+                    .to_string();
+
+                let file_contents = std::fs::read_to_string(&path_buf).map_err(|err| Error {
+                    err,
+                    path: dir_path.to_owned(),
+                })?;
+
+                modules_info.push(ModuleInfo {
+                    path: String::from(path_buf.to_string_lossy()),
+                    name: module_name,
+                    content: file_contents,
+                });
+            }
+        }
+    }
+    // Sort module for consistent codegen
+    modules_info.sort_by(|a, b| a.name.cmp(&b.name));
+    Ok(modules_info)
+}
+
+fn find_queries(start: &PathBuf, mut queries: Vec<PathBuf>) -> Vec<PathBuf> {
+    for entry in start.read_dir().unwrap() {
+        let entry = entry.unwrap();
+        let path = entry.path();
+        if path.is_dir() {
+            queries = find_queries(&path, queries);
+        } else {
+            queries.push(path);
+        }
+    }
+
+    queries
 }
 
 pub(crate) mod error {

--- a/cornucopia/src/read_queries.rs
+++ b/cornucopia/src/read_queries.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use miette::NamedSource;
 
@@ -126,7 +126,7 @@ pub(crate) fn read_query_modules_recursive(dir_path: &str) -> Result<Vec<ModuleI
     Ok(modules_info)
 }
 
-fn find_queries(start: &PathBuf, mut queries: Vec<PathBuf>) -> Vec<PathBuf> {
+fn find_queries(start: &Path, mut queries: Vec<PathBuf>) -> Vec<PathBuf> {
     for entry in start.read_dir().unwrap() {
         let entry = entry.unwrap();
         let path = entry.path();

--- a/integration/src/main.rs
+++ b/integration/src/main.rs
@@ -161,6 +161,7 @@ fn run_errors_test(
                     CodegenSettings {
                         is_async: false,
                         derive_ser: false,
+                        is_recursive: false,
                     },
                 )?;
                 Ok(())
@@ -235,6 +236,7 @@ fn run_codegen_test(
                     CodegenSettings {
                         is_async,
                         derive_ser,
+                        is_recursive: false,
                     },
                 )
                 .map_err(Error::report)?;
@@ -254,6 +256,7 @@ fn run_codegen_test(
                     CodegenSettings {
                         is_async,
                         derive_ser,
+                        is_recursive: false,
                     },
                 )
                 .map_err(Error::report)?;


### PR DESCRIPTION
### Changes

- Added new optional flag to `cli.rs` `--recursive`
- Updated `generate_live` to look for the new flag and use `read_query_modules_recursive` is set to true
- Added new `read_query_modules_recursive` function as a clone of `read_query_modules` to look for directories and if they are found to run `find_queries` to locate all of the files
- Added new `find_queries` function to locate all of the files in a directory and if a directory is found, to call itself with that path

---

This was something I came across when I started using cornucopia for my personal project. I wanted to try to keep my query files as close to where it was going to be used but I wasn't able to find a way to do that as it is. So I made some changes to look into the directories that are found in the given path so you can have a structure like this:

```
├── src
│   ├── product
│   │   ├── mod.rs
│   │   ├── product.sql
│   ├── user
│   │   ├── mod.rs
│   │   ├── user.sql
│   ├── main.rs
```

instead of:

```
├── queries
│   ├── product.sql
│   ├── user.sql
├── src
│   ├── product
│   │   ├── mod.rs
│   ├── user
│   │   ├── mod.rs
│   ├── main.rs
```
I'm not sure if this was wanted or needed but it fits my use case and works for me so I thought I would try to share it.
