### PR TITLE
Release async client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -452,7 +452,7 @@ dependencies = [
 
 [[package]]
 name = "cornucopia_async"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "async-trait",
  "cornucopia_client_core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -581,9 +581,9 @@ dependencies = [
 
 [[package]]
 name = "deadpool-postgres"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40b75ba49590d27f677d3bebaf76cd15889ca8b308bc7ba99bfa25f1d7269c13"
+checksum = "bda39fa1cfff190d8924d447ad04fd22772c250438ca5ce1dfb3c80621c05aaa"
 dependencies = [
  "deadpool",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -452,7 +452,7 @@ dependencies = [
 
 [[package]]
 name = "cornucopia_async"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "cornucopia_client_core",

--- a/crates/client_async/Cargo.toml
+++ b/crates/client_async/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cornucopia_async"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 license = "MIT/Apache-2.0"
 description = "Asynchronous client library for Cornucopia users."

--- a/crates/client_async/Cargo.toml
+++ b/crates/client_async/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cornucopia_async"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2021"
 license = "MIT/Apache-2.0"
 description = "Asynchronous client library for Cornucopia users."

--- a/crates/client_async/Cargo.toml
+++ b/crates/client_async/Cargo.toml
@@ -28,4 +28,4 @@ async-trait = "0.1.63"
 tokio-postgres = "0.7.7"
 
 # connection pooling
-deadpool-postgres = { version = "0.11.0", optional = true }
+deadpool-postgres = { version = "0.12.1", optional = true }

--- a/examples/auto_build/Cargo.toml
+++ b/examples/auto_build/Cargo.toml
@@ -19,7 +19,7 @@ futures = "0.3.25"
 tokio-postgres = "0.7.7"
 postgres-types = "0.2.4"
 ## Connection pooling
-deadpool-postgres = "0.11.0"
+deadpool-postgres = "0.12.1"
 
 [build-dependencies]
 # Cornucopia library to automatically

--- a/examples/basic_async/Cargo.toml
+++ b/examples/basic_async/Cargo.toml
@@ -17,4 +17,4 @@ futures = "0.3.25"
 tokio-postgres = "0.7.7"
 postgres-types = { version = "0.2.4", features = ["derive"] }
 ## Connection pooling
-deadpool-postgres = "0.11.0"
+deadpool-postgres = "0.12.1"


### PR DESCRIPTION
Closes #224  

Release new versions of the async client to allow users to choose a newer version of deadpool-postgres.

In particular, v0.5 supports deadpool-postgres v0.11, while v0.6 support v0.12.