### PR TITLE
Fix container healthcheck

### DIFF
--- a/crates/cornucopia/src/container.rs
+++ b/crates/cornucopia/src/container.rs
@@ -5,7 +5,7 @@ use self::error::Error;
 /// Starts Cornucopia's database container and wait until it reports healthy.
 pub fn setup(podman: bool) -> Result<(), Error> {
     spawn_container(podman)?;
-    healthcheck(podman, 120, 50)?;
+    healthcheck(podman, 120, 500)?;
     Ok(())
 }
 

--- a/crates/cornucopia/src/lib.rs
+++ b/crates/cornucopia/src/lib.rs
@@ -83,7 +83,10 @@ pub fn generate_managed<P: AsRef<Path>>(
         .into_iter()
         .map(parse_query_module)
         .collect::<Result<_, parser::error::Error>>()?;
-    container::setup(podman)?;
+    if let Err(e) = container::setup(podman) {
+        let _ = container::cleanup(podman);
+        return Err(Error::Container(e));
+    }
     let mut client = conn::cornucopia_conn()?;
     load_schema(&mut client, schema_files)?;
     let prepared_modules = prepare(&mut client, modules)?;

--- a/examples/auto_build/_build.rs
+++ b/examples/auto_build/_build.rs
@@ -9,8 +9,9 @@ fn main() -> Result<(), Error> {
     let schema_file = "schema.sql";
     let destination = "src/cornucopia.rs";
     let settings = CodegenSettings {
-        is_async: true,
-        derive_ser: false,
+        gen_async: true,
+        gen_sync: false,
+        derive_ser: true,
     };
 
     println!("cargo:rerun-if-changed={queries_path}");

--- a/examples/auto_build/src/cornucopia.rs
+++ b/examples/auto_build/src/cornucopia.rs
@@ -1,93 +1,62 @@
 // This file was generated with `cornucopia`. Do not modify.
 
-#[allow(clippy::all, clippy::pedantic)]
-#[allow(unused_variables)]
-#[allow(unused_imports)]
-#[allow(dead_code)]
-pub mod types {}
-#[allow(clippy::all, clippy::pedantic)]
-#[allow(unused_variables)]
-#[allow(unused_imports)]
-#[allow(dead_code)]
-pub mod queries {
-    pub mod module_1 {
-        use cornucopia_async::GenericClient;
-        use futures;
-        use futures::{StreamExt, TryStreamExt};
-        pub struct StringQuery<'a, C: GenericClient, T, const N: usize> {
-            client: &'a C,
-            params: [&'a (dyn postgres_types::ToSql + Sync); N],
-            stmt: &'a mut cornucopia_async::private::Stmt,
-            extractor: fn(&tokio_postgres::Row) -> &str,
-            mapper: fn(&str) -> T,
-        }
-        impl<'a, C, T: 'a, const N: usize> StringQuery<'a, C, T, N>
-        where
-            C: GenericClient,
+ #[allow(clippy::all, clippy::pedantic)] #[allow(unused_variables)]
+#[allow(unused_imports)] #[allow(dead_code)] pub mod types { } #[allow(clippy::all, clippy::pedantic)] #[allow(unused_variables)]
+#[allow(unused_imports)] #[allow(dead_code)] pub mod queries
+{  pub mod module_1
+{   use futures::{StreamExt, TryStreamExt};use futures; use cornucopia_async::GenericClient; pub struct StringQuery<'a, C: GenericClient, T, const N: usize>
+{
+    client: &'a  C, params:
+    [&'a (dyn postgres_types::ToSql + Sync); N], stmt: &'a mut
+    cornucopia_async::private::Stmt, extractor: fn(&tokio_postgres::Row) -> & str,
+    mapper: fn(& str) -> T,
+} impl<'a, C, T:'a, const N: usize> StringQuery<'a, C, T, N> where C:
+GenericClient
+{
+    pub fn map<R>(self, mapper: fn(& str) -> R) ->
+    StringQuery<'a,C,R,N>
+    {
+        StringQuery
         {
-            pub fn map<R>(self, mapper: fn(&str) -> R) -> StringQuery<'a, C, R, N> {
-                StringQuery {
-                    client: self.client,
-                    params: self.params,
-                    stmt: self.stmt,
-                    extractor: self.extractor,
-                    mapper,
-                }
-            }
-            pub async fn one(self) -> Result<T, tokio_postgres::Error> {
-                let stmt = self.stmt.prepare(self.client).await?;
-                let row = self.client.query_one(stmt, &self.params).await?;
-                Ok((self.mapper)((self.extractor)(&row)))
-            }
-            pub async fn all(self) -> Result<Vec<T>, tokio_postgres::Error> {
-                self.iter().await?.try_collect().await
-            }
-            pub async fn opt(self) -> Result<Option<T>, tokio_postgres::Error> {
-                let stmt = self.stmt.prepare(self.client).await?;
-                Ok(self
-                    .client
-                    .query_opt(stmt, &self.params)
-                    .await?
-                    .map(|row| (self.mapper)((self.extractor)(&row))))
-            }
-            pub async fn iter(
-                self,
-            ) -> Result<
-                impl futures::Stream<Item = Result<T, tokio_postgres::Error>> + 'a,
-                tokio_postgres::Error,
-            > {
-                let stmt = self.stmt.prepare(self.client).await?;
-                let it = self
-                    .client
-                    .query_raw(stmt, cornucopia_async::private::slice_iter(&self.params))
-                    .await?
-                    .map(move |res| res.map(|row| (self.mapper)((self.extractor)(&row))))
-                    .into_stream();
-                Ok(it)
-            }
+            client: self.client, params: self.params, stmt: self.stmt,
+            extractor: self.extractor, mapper,
         }
-        pub fn example_query() -> ExampleQueryStmt {
-            ExampleQueryStmt(cornucopia_async::private::Stmt::new(
-                "SELECT
+    } pub async fn one(self) -> Result<T, tokio_postgres::Error>
+    {
+        let stmt = self.stmt.prepare(self.client).await?; let row =
+        self.client.query_one(stmt, &self.params).await?;
+        Ok((self.mapper)((self.extractor)(&row)))
+    } pub async fn all(self) -> Result<Vec<T>, tokio_postgres::Error>
+    { self.iter().await?.try_collect().await } pub async fn opt(self) ->
+    Result<Option<T>, tokio_postgres::Error>
+    {
+        let stmt = self.stmt.prepare(self.client).await?;
+        Ok(self.client.query_opt(stmt, &self.params) .await?
+        .map(|row| (self.mapper)((self.extractor)(&row))))
+    } pub async fn iter(self,) -> Result<impl futures::Stream<Item = Result<T,
+    tokio_postgres::Error>> + 'a, tokio_postgres::Error>
+    {
+        let stmt = self.stmt.prepare(self.client).await?; let it =
+        self.client.query_raw(stmt,
+        cornucopia_async::private::slice_iter(&self.params)) .await?
+        .map(move |res|
+        res.map(|row| (self.mapper)((self.extractor)(&row)))) .into_stream();
+        Ok(it)
+    }
+} pub fn example_query() -> ExampleQueryStmt
+{ ExampleQueryStmt(cornucopia_async::private::Stmt::new("SELECT
     *
 FROM
-    example_table",
-            ))
-        }
-        pub struct ExampleQueryStmt(cornucopia_async::private::Stmt);
-        impl ExampleQueryStmt {
-            pub fn bind<'a, C: GenericClient>(
-                &'a mut self,
-                client: &'a C,
-            ) -> StringQuery<'a, C, String, 0> {
-                StringQuery {
-                    client,
-                    params: [],
-                    stmt: &mut self.0,
-                    extractor: |row| row.get(0),
-                    mapper: |it| it.into(),
-                }
-            }
-        }
+    example_table")) } pub struct
+ExampleQueryStmt(cornucopia_async::private::Stmt); impl ExampleQueryStmt
+{  pub fn bind<'a, C:
+GenericClient,>(&'a mut self, client: &'a  C,
+) -> StringQuery<'a,C,
+String, 0>
+{
+    StringQuery
+    {
+        client, params: [], stmt: &mut self.0, extractor:
+        |row| {  row.get(0) }, mapper: |it| { it.into() },
     }
-}
+} } }}


### PR DESCRIPTION
Previous container creation logic had the following 2 issues afaik:

1. Health check was too quick. Increasing this from `50` to `500` fixed the problem for me on M2 Max.
2. Container setup logic didn't do cleanup after failure. Resulted in error messages like `Conflict. The container name \"/cornucopia_postgres\" is already in use by container` on subsequent startup.

Misc:

- Fix the build script for `auto_build` example.

This fixes https://github.com/cornucopia-rs/cornucopia/issues/244