### PR TITLE
CI: Nightly job to upgrade compatible dependencies

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,47 +7,25 @@ jobs:
     name: Test Suite
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - uses: Swatinem/rust-cache@v1
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --all
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo test
 
   fmt:
     name: Rustfmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - run: rustup component add rustfmt
-      - uses: actions-rs/cargo@v1
-        with:
-          command: fmt
-          args: --all -- --check
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo fmt --all -- --check
 
   clippy:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-      - run: rustup component add clippy
-      - uses: Swatinem/rust-cache@v1
-      - uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: -- -D warnings
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo clippy -- -D warnings

--- a/.github/workflows/upgrade-dependencies.yml
+++ b/.github/workflows/upgrade-dependencies.yml
@@ -1,0 +1,26 @@
+name: Upgrade dependencies
+
+on:
+  workflow_dispatch: {}
+  schedule:
+    - cron: 0 2 * * *
+
+jobs:
+  upgrade-dependencies:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo install cargo-edit
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo upgrade
+      - run: cargo test
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          commit-message: "fix: Upgrade dependencies"
+          title: "Upgrade dependencies to their latest compatible version"
+          body: |
+            Upgrade to compatible dependencies. This was automatically done using cargo-edit.
+            ```
+          branch: create-pull-request/upgrade-dependencies


### PR DESCRIPTION
Merging this PR will enable a new Github workflow that runs [cargo-edit's upgrade command](https://github.com/killercup/cargo-edit?tab=readme-ov-file#cargo-upgrade) every night. Then tests are run and finally a PR is created if any changes are noticed.

IMHO next step is to automate the release process 😀

Please note that your unit tests are currently failing with a lifetime error because of an old subdependency of yours called rustc-serialize. Merging #250 will fix that problem.

Also note that this PR updates the existing CI workflow to get rid of deprecation warnings.