### PR TITLE
Disable the default features of eui48

### DIFF
--- a/test_codegen/Cargo.toml
+++ b/test_codegen/Cargo.toml
@@ -39,5 +39,5 @@ serde = { version = "1.0.152", features = ["derive"] }
 serde_json = { version = "1.0.91", features = ["raw_value"] }
 time = { version = "0.3.17", features = ["parsing", "serde"] }
 uuid = { version = "1.2.2", features = ["serde"] }
-eui48 = { version = "1.1.0", features = ["serde"] }
+eui48 = { version = "1.1.0", default-features = false, features = ["serde"] }
 rust_decimal = { version = "1.28.0", features = ["db-postgres"] }


### PR DESCRIPTION
The default features of the eui48 crate add a dependency to the [rustc-serialize](https://crates.io/crates/rustc-serialize) crate. This crate is deprecated and the repository archived since Dec 1, 2023.

Will fix #228.