### PR TITLE
Add support for type mapping

### DIFF
--- a/benches/codegen.rs
+++ b/benches/codegen.rs
@@ -17,6 +17,7 @@ fn bench(c: &mut Criterion) {
                     gen_sync: true,
                     gen_async: false,
                     derive_ser: true,
+                    config: Default::default(),
                 },
             )
             .unwrap()
@@ -32,6 +33,7 @@ fn bench(c: &mut Criterion) {
                     gen_sync: true,
                     gen_async: false,
                     derive_ser: true,
+                    config: Default::default(),
                 },
             )
             .unwrap()

--- a/benches/execution/diesel_benches.rs
+++ b/benches/execution/diesel_benches.rs
@@ -164,10 +164,7 @@ pub fn bench_insert(b: &mut Bencher, conn: &mut PgConnection, size: usize) {
     };
     let insert = &insert;
 
-    b.iter(|| {
-        let insert = insert;
-        insert(conn)
-    })
+    b.iter(|| insert(conn))
 }
 
 pub fn loading_associations_sequentially(b: &mut Bencher, conn: &mut PgConnection) {

--- a/crates/cornucopia/Cargo.toml
+++ b/crates/cornucopia/Cargo.toml
@@ -33,3 +33,7 @@ heck = "0.4.0"
 
 # Order-preserving map to work around borrowing issues
 indexmap = "2.0.2"
+
+# Config handling
+serde = { version = "1.0.203", features = ["derive"] }
+toml = "0.8.14"

--- a/crates/cornucopia/src/config.rs
+++ b/crates/cornucopia/src/config.rs
@@ -1,0 +1,12 @@
+//! Configuration for Cornucopia.
+
+use std::collections::HashMap;
+
+use serde::Deserialize;
+
+/// Configuration for Cornucopia.
+#[derive(Clone, Deserialize, Default, Debug)]
+pub struct Config {
+    /// Contains a map of what given type should map to.
+    pub custom_type_map: HashMap<String, String>,
+}

--- a/crates/cornucopia/src/utils.rs
+++ b/crates/cornucopia/src/utils.rs
@@ -5,8 +5,17 @@ use postgres_types::Type;
 /// Allows us to query a map using type schema as key without having to own the key strings
 #[derive(PartialEq, Eq, Hash)]
 pub struct SchemaKey<'a> {
-    schema: &'a str,
-    name: &'a str,
+    /// The schema of this type.
+    pub schema: &'a str,
+    /// The name of this type.
+    pub name: &'a str,
+}
+
+impl<'a> SchemaKey<'a> {
+    /// Creates a new [`SchemaKey`] from the specified components.
+    pub fn new(schema: &'a str, name: &'a str) -> Self {
+        SchemaKey { schema, name }
+    }
 }
 
 impl<'a> From<&'a Type> for SchemaKey<'a> {

--- a/test_integration/src/fixtures.rs
+++ b/test_integration/src/fixtures.rs
@@ -77,6 +77,7 @@ impl From<&CodegenTest> for CodegenSettings {
             gen_async: codegen_test.r#async || !codegen_test.sync,
             gen_sync: codegen_test.sync,
             derive_ser: codegen_test.derive_ser,
+            config: Default::default(),
         }
     }
 }
@@ -96,6 +97,7 @@ impl From<&ErrorTest> for CodegenSettings {
             derive_ser: false,
             gen_async: false,
             gen_sync: true,
+            config: Default::default(),
         }
     }
 }


### PR DESCRIPTION
Similar to Kanel's customTypeMap.

One use case for this is allowing one to treat PG extension types as some other types that they behave as (e.g., map public.ulid to String).

This allows treating a type as some custom type, requiring the user to implement `ToSql`, `FromSql`, and a `XxxBorrowed` variant on it. Additionally, we treat mapping to `String` as a special case.

This is a POC for #246. Happy to improve the PR and add tests if the direction sounds good.