### PR TITLE
Remove transitive dependency on `mio`

### DIFF
--- a/crates/client_async/Cargo.toml
+++ b/crates/client_async/Cargo.toml
@@ -25,7 +25,7 @@ cornucopia_client_core = { path = "../client_core", version = "0.4.0" }
 async-trait = "0.1.63"
 
 # rust-postgres interaction
-tokio-postgres = "0.7.7"
+tokio-postgres = { version = "0.7.7", default-features = false }
 
 # connection pooling
 deadpool-postgres = { version = "0.12.1", optional = true }


### PR DESCRIPTION
Removes the transitive dependency on `mio`. This allows projects targeting `wasm32-unknown-unknown` to compile.

The `mio` dependency is being brought in via: `cornucopia_async`→`tokio-postgres`→`tokio-postgres/runtime`→`tokio/net`→`mio`. By disabling the default features of `tokio-postgres`, we disable its `runtime` feature.

[`axum`'s comment on `mio`](https://github.com/tokio-rs/axum/blob/main/examples/simple-router-wasm/src/main.rs#L10-L12):
> [`mio`](https://docs.rs/mio/latest/mio/index.html), tokio's IO layer, does not support the  `wasm32-unknown-unknown` target which is why this crate requires `default-features = false` for axum.


### Reproduction Steps
1. Install the "wasm32-unknown-unknown" target
`rustup target add wasm32-unknown-unknown`
2. Create a dummy WASM library
`cargo install cargo-generate && cargo generate --git https://github.com/rustwasm/wasm-pack-template`
3. Add "tokio-postgres"
`cargo add tokio-postgres@0.7.11 --no-default-features --features js`
4. Confirm that project builds
`cargo build --target wasm32-unknown-unknown`
`cargo tree --target wasm32-unknown-unknown --invert mio` (no matches is what we want)
5. Add "cornucopia_async"
`cargo add cornucopia_async@0.6.0 --no-default-features`
6. Project no longer builds
`cargo build --target wasm32-unknown-unknown`
`cargo tree --target wasm32-unknown-unknown --invert mio`

<details><summary><h3>Build log & errors</h3></summary>
<pre><code>$ cargo build --target wasm32-unknown-unknown                                                                                   6s 09:29:18
   Compiling mio v1.0.2
   Compiling cornucopia_client_core v0.4.0
error[E0432]: unresolved import `crate::sys::IoSourceState`
  --> /Users/ts-sandroama.marques/.cargo/registry/src/index.crates.io-6f17d22bba15001f/mio-1.0.2/src/io_source.rs:14:5
   |
14 | use crate::sys::IoSourceState;
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^ no `IoSourceState` in `sys`

error[E0432]: unresolved import `crate::sys::tcp`
  --> /Users/ts-sandroama.marques/.cargo/registry/src/index.crates.io-6f17d22bba15001f/mio-1.0.2/src/net/tcp/listener.rs:17:17
   |
17 | use crate::sys::tcp::{bind, listen, new_for_addr};
   |                 ^^^ could not find `tcp` in `sys`

error[E0432]: unresolved import `crate::sys::tcp`
  --> /Users/ts-sandroama.marques/.cargo/registry/src/index.crates.io-6f17d22bba15001f/mio-1.0.2/src/net/tcp/stream.rs:15:17
   |
15 | use crate::sys::tcp::{connect, new_for_addr};
   |                 ^^^ could not find `tcp` in `sys`

error[E0433]: failed to resolve: could not find `Selector` in `sys`
   --> /Users/ts-sandroama.marques/.cargo/registry/src/index.crates.io-6f17d22bba15001f/mio-1.0.2/src/poll.rs:321:18
    |
321 |             sys::Selector::new().map(|selector| Poll {
    |                  ^^^^^^^^ could not find `Selector` in `sys`

error[E0433]: failed to resolve: could not find `event` in `sys`
  --> /Users/ts-sandroama.marques/.cargo/registry/src/index.crates.io-6f17d22bba15001f/mio-1.0.2/src/event/event.rs:24:14
   |
24 |         sys::event::token(&self.inner)
   |              ^^^^^ could not find `event` in `sys`

error[E0433]: failed to resolve: could not find `event` in `sys`
  --> /Users/ts-sandroama.marques/.cargo/registry/src/index.crates.io-6f17d22bba15001f/mio-1.0.2/src/event/event.rs:38:14
   |
38 |         sys::event::is_readable(&self.inner)
   |              ^^^^^ could not find `event` in `sys`

error[E0433]: failed to resolve: could not find `event` in `sys`
  --> /Users/ts-sandroama.marques/.cargo/registry/src/index.crates.io-6f17d22bba15001f/mio-1.0.2/src/event/event.rs:43:14
   |
43 |         sys::event::is_writable(&self.inner)
   |              ^^^^^ could not find `event` in `sys`

error[E0433]: failed to resolve: could not find `event` in `sys`
  --> /Users/ts-sandroama.marques/.cargo/registry/src/index.crates.io-6f17d22bba15001f/mio-1.0.2/src/event/event.rs:68:14
   |
68 |         sys::event::is_error(&self.inner)
   |              ^^^^^ could not find `event` in `sys`

error[E0433]: failed to resolve: could not find `event` in `sys`
  --> /Users/ts-sandroama.marques/.cargo/registry/src/index.crates.io-6f17d22bba15001f/mio-1.0.2/src/event/event.rs:99:14
   |
99 |         sys::event::is_read_closed(&self.inner)
   |              ^^^^^ could not find `event` in `sys`

error[E0433]: failed to resolve: could not find `event` in `sys`
   --> /Users/ts-sandroama.marques/.cargo/registry/src/index.crates.io-6f17d22bba15001f/mio-1.0.2/src/event/event.rs:129:14
    |
129 |         sys::event::is_write_closed(&self.inner)
    |              ^^^^^ could not find `event` in `sys`

error[E0433]: failed to resolve: could not find `event` in `sys`
   --> /Users/ts-sandroama.marques/.cargo/registry/src/index.crates.io-6f17d22bba15001f/mio-1.0.2/src/event/event.rs:151:14
    |
151 |         sys::event::is_priority(&self.inner)
    |              ^^^^^ could not find `event` in `sys`

error[E0433]: failed to resolve: could not find `event` in `sys`
   --> /Users/ts-sandroama.marques/.cargo/registry/src/index.crates.io-6f17d22bba15001f/mio-1.0.2/src/event/event.rs:173:14
    |
173 |         sys::event::is_aio(&self.inner)
    |              ^^^^^ could not find `event` in `sys`

error[E0433]: failed to resolve: could not find `event` in `sys`
   --> /Users/ts-sandroama.marques/.cargo/registry/src/index.crates.io-6f17d22bba15001f/mio-1.0.2/src/event/event.rs:183:14
    |
183 |         sys::event::is_lio(&self.inner)
    |              ^^^^^ could not find `event` in `sys`

error[E0433]: failed to resolve: could not find `event` in `sys`
   --> /Users/ts-sandroama.marques/.cargo/registry/src/index.crates.io-6f17d22bba15001f/mio-1.0.2/src/event/event.rs:221:26
    |
221 |                     sys::event::debug_details(f, self.0)
    |                          ^^^^^ could not find `event` in `sys`

error[E0433]: failed to resolve: could not find `tcp` in `sys`
   --> /Users/ts-sandroama.marques/.cargo/registry/src/index.crates.io-6f17d22bba15001f/mio-1.0.2/src/net/tcp/listener.rs:105:18
    |
105 |             sys::tcp::accept(inner).map(|(stream, addr)| (TcpStream::from_std(stream), addr))
    |                  ^^^ could not find `tcp` in `sys`

error[E0433]: failed to resolve: could not find `udp` in `sys`
   --> /Users/ts-sandroama.marques/.cargo/registry/src/index.crates.io-6f17d22bba15001f/mio-1.0.2/src/net/udp.rs:124:14
    |
124 |         sys::udp::bind(addr).map(UdpSocket::from_std)
    |              ^^^ could not find `udp` in `sys`

error[E0433]: failed to resolve: could not find `udp` in `sys`
   --> /Users/ts-sandroama.marques/.cargo/registry/src/index.crates.io-6f17d22bba15001f/mio-1.0.2/src/net/udp.rs:546:14
    |
546 |         sys::udp::only_v6(&self.inner)
    |              ^^^ could not find `udp` in `sys`

error[E0412]: cannot find type `Selector` in module `sys`
   --> /Users/ts-sandroama.marques/.cargo/registry/src/index.crates.io-6f17d22bba15001f/mio-1.0.2/src/poll.rs:272:20
    |
272 |     selector: sys::Selector,
    |                    ^^^^^^^^ not found in `sys`

error[E0412]: cannot find type `Selector` in module `sys`
   --> /Users/ts-sandroama.marques/.cargo/registry/src/index.crates.io-6f17d22bba15001f/mio-1.0.2/src/poll.rs:728:44
    |
728 |     pub(crate) fn selector(&self) -> &sys::Selector {
    |                                            ^^^^^^^^ not found in `sys`

error[E0412]: cannot find type `Waker` in module `sys`
  --> /Users/ts-sandroama.marques/.cargo/registry/src/index.crates.io-6f17d22bba15001f/mio-1.0.2/src/waker.rs:79:17
   |
79 |     inner: sys::Waker,
   |                 ^^^^^ not found in `sys`
   |
help: consider importing one of these items
   |
1  + use core::task::Waker;
   |
1  + use crate::Waker;
   |
1  + use std::task::Waker;
   |
help: if you import `Waker`, refer to it directly
   |
79 -     inner: sys::Waker,
79 +     inner: Waker,
   |

error[E0433]: failed to resolve: could not find `Waker` in `sys`
  --> /Users/ts-sandroama.marques/.cargo/registry/src/index.crates.io-6f17d22bba15001f/mio-1.0.2/src/waker.rs:87:14
   |
87 |         sys::Waker::new(registry.selector(), token).map(|inner| Waker { inner })
   |              ^^^^^ could not find `Waker` in `sys`
   |
help: consider importing one of these items
   |
1  + use core::task::Waker;
   |
1  + use crate::Waker;
   |
1  + use std::task::Waker;
   |
help: if you import `Waker`, refer to it directly
   |
87 -         sys::Waker::new(registry.selector(), token).map(|inner| Waker { inner })
87 +         Waker::new(registry.selector(), token).map(|inner| Waker { inner })
   |

error[E0412]: cannot find type `Event` in module `sys`
  --> /Users/ts-sandroama.marques/.cargo/registry/src/index.crates.io-6f17d22bba15001f/mio-1.0.2/src/event/event.rs:18:17
   |
18 |     inner: sys::Event,
   |                 ^^^^^ not found in `sys`
   |
help: consider importing this struct through its public re-export
   |
1  + use crate::event::Event;
   |
help: if you import `Event`, refer to it directly
   |
18 -     inner: sys::Event,
18 +     inner: Event,
   |

error[E0412]: cannot find type `Event` in module `sys`
   --> /Users/ts-sandroama.marques/.cargo/registry/src/index.crates.io-6f17d22bba15001f/mio-1.0.2/src/event/event.rs:187:55
    |
187 |     pub(crate) fn from_sys_event_ref(sys_event: &sys::Event) -> &Event {
    |                                                       ^^^^^ not found in `sys`
    |
help: consider importing this struct through its public re-export
    |
1   + use crate::event::Event;
    |
help: if you import `Event`, refer to it directly
    |
187 -     pub(crate) fn from_sys_event_ref(sys_event: &sys::Event) -> &Event {
187 +     pub(crate) fn from_sys_event_ref(sys_event: &Event) -> &Event {
    |

error[E0412]: cannot find type `Event` in module `sys`
   --> /Users/ts-sandroama.marques/.cargo/registry/src/index.crates.io-6f17d22bba15001f/mio-1.0.2/src/event/event.rs:191:41
    |
191 |             &*(sys_event as *const sys::Event as *const Event)
    |                                         ^^^^^ not found in `sys`
    |
help: consider importing this struct through its public re-export
    |
1   + use crate::event::Event;
    |
help: if you import `Event`, refer to it directly
    |
191 -             &*(sys_event as *const sys::Event as *const Event)
191 +             &*(sys_event as *const Event as *const Event)
    |

error[E0412]: cannot find type `Event` in module `sys`
   --> /Users/ts-sandroama.marques/.cargo/registry/src/index.crates.io-6f17d22bba15001f/mio-1.0.2/src/event/event.rs:217:46
    |
217 |             struct EventDetails<'a>(&'a sys::Event);
    |                                              ^^^^^ not found in `sys`
    |
help: consider importing this struct through its public re-export
    |
1   + use crate::event::Event;
    |
help: if you import `Event`, refer to it directly
    |
217 -             struct EventDetails<'a>(&'a sys::Event);
217 +             struct EventDetails<'a>(&'a Event);
    |

error[E0412]: cannot find type `Events` in module `sys`
  --> /Users/ts-sandroama.marques/.cargo/registry/src/index.crates.io-6f17d22bba15001f/mio-1.0.2/src/event/events.rs:43:17
   |
43 |     inner: sys::Events,
   |                 ^^^^^^ not found in `sys`
   |
help: consider importing this struct through its public re-export
   |
1  + use crate::Events;
   |
help: if you import `Events`, refer to it directly
   |
43 -     inner: sys::Events,
43 +     inner: Events,
   |

error[E0433]: failed to resolve: could not find `Events` in `sys`
  --> /Users/ts-sandroama.marques/.cargo/registry/src/index.crates.io-6f17d22bba15001f/mio-1.0.2/src/event/events.rs:94:25
   |
94 |             inner: sys::Events::with_capacity(capacity),
   |                         ^^^^^^ could not find `Events` in `sys`
   |
help: consider importing this struct through its public re-export
   |
1  + use crate::Events;
   |
help: if you import `Events`, refer to it directly
   |
94 -             inner: sys::Events::with_capacity(capacity),
94 +             inner: Events::with_capacity(capacity),
   |

error[E0412]: cannot find type `Events` in module `sys`
   --> /Users/ts-sandroama.marques/.cargo/registry/src/index.crates.io-6f17d22bba15001f/mio-1.0.2/src/event/events.rs:189:47
    |
189 |     pub(crate) fn sys(&mut self) -> &mut sys::Events {
    |                                               ^^^^^^ not found in `sys`
    |
help: consider importing this struct through its public re-export
    |
1   + use crate::Events;
    |
help: if you import `Events`, refer to it directly
    |
189 -     pub(crate) fn sys(&mut self) -> &mut sys::Events {
189 +     pub(crate) fn sys(&mut self) -> &mut Events {
    |

error[E0425]: cannot find value `listener` in this scope
  --> /Users/ts-sandroama.marques/.cargo/registry/src/index.crates.io-6f17d22bba15001f/mio-1.0.2/src/net/tcp/listener.rs:76:24
   |
76 |         set_reuseaddr(&listener.inner, true)?;
   |                        ^^^^^^^^ not found in this scope

error[E0425]: cannot find value `listener` in this scope
  --> /Users/ts-sandroama.marques/.cargo/registry/src/index.crates.io-6f17d22bba15001f/mio-1.0.2/src/net/tcp/listener.rs:78:15
   |
78 |         bind(&listener.inner, addr)?;
   |               ^^^^^^^^ not found in this scope

error[E0425]: cannot find value `listener` in this scope
  --> /Users/ts-sandroama.marques/.cargo/registry/src/index.crates.io-6f17d22bba15001f/mio-1.0.2/src/net/tcp/listener.rs:79:17
   |
79 |         listen(&listener.inner, 1024)?;
   |                 ^^^^^^^^ not found in this scope

error[E0425]: cannot find value `listener` in this scope
  --> /Users/ts-sandroama.marques/.cargo/registry/src/index.crates.io-6f17d22bba15001f/mio-1.0.2/src/net/tcp/listener.rs:80:12
   |
80 |         Ok(listener)
   |            ^^^^^^^^ not found in this scope

error[E0425]: cannot find value `stream` in this scope
  --> /Users/ts-sandroama.marques/.cargo/registry/src/index.crates.io-6f17d22bba15001f/mio-1.0.2/src/net/tcp/stream.rs:95:18
   |
95 |         connect(&stream.inner, addr)?;
   |                  ^^^^^^ not found in this scope

error[E0425]: cannot find value `stream` in this scope
  --> /Users/ts-sandroama.marques/.cargo/registry/src/index.crates.io-6f17d22bba15001f/mio-1.0.2/src/net/tcp/stream.rs:96:12
   |
96 |         Ok(stream)
   |            ^^^^^^ not found in this scope

error[E0425]: cannot find function `set_reuseaddr` in this scope
  --> /Users/ts-sandroama.marques/.cargo/registry/src/index.crates.io-6f17d22bba15001f/mio-1.0.2/src/net/tcp/listener.rs:76:9
   |
76 |         set_reuseaddr(&listener.inner, true)?;
   |         ^^^^^^^^^^^^^ not found in this scope

error[E0599]: no method named `register` found for struct `IoSource<std::net::TcpListener>` in the current scope
   --> /Users/ts-sandroama.marques/.cargo/registry/src/index.crates.io-6f17d22bba15001f/mio-1.0.2/src/net/tcp/listener.rs:148:20
    |
148 |         self.inner.register(registry, token, interests)
    |                    ^^^^^^^^ method not found in `IoSource<TcpListener>`
    |
   ::: /Users/ts-sandroama.marques/.cargo/registry/src/index.crates.io-6f17d22bba15001f/mio-1.0.2/src/io_source.rs:37:1
    |
37  | pub struct IoSource<T> {
    | ---------------------- method `register` not found for this struct
    |
    = help: items from traits can only be used if the trait is implemented and in scope
note: `Source` defines an item `register`, perhaps you need to implement it
   --> /Users/ts-sandroama.marques/.cargo/registry/src/index.crates.io-6f17d22bba15001f/mio-1.0.2/src/event/source.rs:75:1
    |
75  | pub trait Source {
    | ^^^^^^^^^^^^^^^^

error[E0599]: no method named `reregister` found for struct `IoSource<std::net::TcpListener>` in the current scope
   --> /Users/ts-sandroama.marques/.cargo/registry/src/index.crates.io-6f17d22bba15001f/mio-1.0.2/src/net/tcp/listener.rs:157:20
    |
157 |         self.inner.reregister(registry, token, interests)
    |                    ^^^^^^^^^^ method not found in `IoSource<TcpListener>`
    |
   ::: /Users/ts-sandroama.marques/.cargo/registry/src/index.crates.io-6f17d22bba15001f/mio-1.0.2/src/io_source.rs:37:1
    |
37  | pub struct IoSource<T> {
    | ---------------------- method `reregister` not found for this struct
    |
    = help: items from traits can only be used if the trait is implemented and in scope
note: `Source` defines an item `reregister`, perhaps you need to implement it
   --> /Users/ts-sandroama.marques/.cargo/registry/src/index.crates.io-6f17d22bba15001f/mio-1.0.2/src/event/source.rs:75:1
    |
75  | pub trait Source {
    | ^^^^^^^^^^^^^^^^

error[E0599]: no method named `deregister` found for struct `IoSource<std::net::TcpListener>` in the current scope
   --> /Users/ts-sandroama.marques/.cargo/registry/src/index.crates.io-6f17d22bba15001f/mio-1.0.2/src/net/tcp/listener.rs:161:20
    |
161 |         self.inner.deregister(registry)
    |                    ^^^^^^^^^^ method not found in `IoSource<TcpListener>`
    |
   ::: /Users/ts-sandroama.marques/.cargo/registry/src/index.crates.io-6f17d22bba15001f/mio-1.0.2/src/io_source.rs:37:1
    |
37  | pub struct IoSource<T> {
    | ---------------------- method `deregister` not found for this struct
    |
    = help: items from traits can only be used if the trait is implemented and in scope
note: `Source` defines an item `deregister`, perhaps you need to implement it
   --> /Users/ts-sandroama.marques/.cargo/registry/src/index.crates.io-6f17d22bba15001f/mio-1.0.2/src/event/source.rs:75:1
    |
75  | pub trait Source {
    | ^^^^^^^^^^^^^^^^

error[E0308]: mismatched types
   --> /Users/ts-sandroama.marques/.cargo/registry/src/index.crates.io-6f17d22bba15001f/mio-1.0.2/src/net/tcp/listener.rs:237:9
    |
237 | /         unsafe {
238 | |             #[cfg(any(unix, target_os = "hermit", target_os = "wasi"))]
239 | |             {
240 | |                 net::TcpListener::from_raw_fd(listener.into_raw_fd())
...   |
245 | |             }
246 | |         }
    | |_________^ expected `TcpListener`, found `()`

error[E0599]: no method named `register` found for struct `IoSource<std::net::TcpStream>` in the current scope
   --> /Users/ts-sandroama.marques/.cargo/registry/src/index.crates.io-6f17d22bba15001f/mio-1.0.2/src/net/tcp/stream.rs:330:20
    |
330 |         self.inner.register(registry, token, interests)
    |                    ^^^^^^^^ method not found in `IoSource<TcpStream>`
    |
   ::: /Users/ts-sandroama.marques/.cargo/registry/src/index.crates.io-6f17d22bba15001f/mio-1.0.2/src/io_source.rs:37:1
    |
37  | pub struct IoSource<T> {
    | ---------------------- method `register` not found for this struct
    |
    = help: items from traits can only be used if the trait is implemented and in scope
note: `Source` defines an item `register`, perhaps you need to implement it
   --> /Users/ts-sandroama.marques/.cargo/registry/src/index.crates.io-6f17d22bba15001f/mio-1.0.2/src/event/source.rs:75:1
    |
75  | pub trait Source {
    | ^^^^^^^^^^^^^^^^

error[E0599]: no method named `reregister` found for struct `IoSource<std::net::TcpStream>` in the current scope
   --> /Users/ts-sandroama.marques/.cargo/registry/src/index.crates.io-6f17d22bba15001f/mio-1.0.2/src/net/tcp/stream.rs:339:20
    |
339 |         self.inner.reregister(registry, token, interests)
    |                    ^^^^^^^^^^ method not found in `IoSource<TcpStream>`
    |
   ::: /Users/ts-sandroama.marques/.cargo/registry/src/index.crates.io-6f17d22bba15001f/mio-1.0.2/src/io_source.rs:37:1
    |
37  | pub struct IoSource<T> {
    | ---------------------- method `reregister` not found for this struct
    |
    = help: items from traits can only be used if the trait is implemented and in scope
note: `Source` defines an item `reregister`, perhaps you need to implement it
   --> /Users/ts-sandroama.marques/.cargo/registry/src/index.crates.io-6f17d22bba15001f/mio-1.0.2/src/event/source.rs:75:1
    |
75  | pub trait Source {
    | ^^^^^^^^^^^^^^^^

error[E0599]: no method named `deregister` found for struct `IoSource<std::net::TcpStream>` in the current scope
   --> /Users/ts-sandroama.marques/.cargo/registry/src/index.crates.io-6f17d22bba15001f/mio-1.0.2/src/net/tcp/stream.rs:343:20
    |
343 |         self.inner.deregister(registry)
    |                    ^^^^^^^^^^ method not found in `IoSource<TcpStream>`
    |
   ::: /Users/ts-sandroama.marques/.cargo/registry/src/index.crates.io-6f17d22bba15001f/mio-1.0.2/src/io_source.rs:37:1
    |
37  | pub struct IoSource<T> {
    | ---------------------- method `deregister` not found for this struct
    |
    = help: items from traits can only be used if the trait is implemented and in scope
note: `Source` defines an item `deregister`, perhaps you need to implement it
   --> /Users/ts-sandroama.marques/.cargo/registry/src/index.crates.io-6f17d22bba15001f/mio-1.0.2/src/event/source.rs:75:1
    |
75  | pub trait Source {
    | ^^^^^^^^^^^^^^^^

error[E0308]: mismatched types
   --> /Users/ts-sandroama.marques/.cargo/registry/src/index.crates.io-6f17d22bba15001f/mio-1.0.2/src/net/tcp/stream.rs:419:9
    |
419 | /         unsafe {
420 | |             #[cfg(any(unix, target_os = "hermit", target_os = "wasi"))]
421 | |             {
422 | |                 net::TcpStream::from_raw_fd(stream.into_raw_fd())
...   |
427 | |             }
428 | |         }
    | |_________^ expected `TcpStream`, found `()`

error[E0599]: no method named `register` found for struct `IoSource<std::net::UdpSocket>` in the current scope
   --> /Users/ts-sandroama.marques/.cargo/registry/src/index.crates.io-6f17d22bba15001f/mio-1.0.2/src/net/udp.rs:624:20
    |
624 |         self.inner.register(registry, token, interests)
    |                    ^^^^^^^^ method not found in `IoSource<UdpSocket>`
    |
   ::: /Users/ts-sandroama.marques/.cargo/registry/src/index.crates.io-6f17d22bba15001f/mio-1.0.2/src/io_source.rs:37:1
    |
37  | pub struct IoSource<T> {
    | ---------------------- method `register` not found for this struct
    |
    = help: items from traits can only be used if the trait is implemented and in scope
note: `Source` defines an item `register`, perhaps you need to implement it
   --> /Users/ts-sandroama.marques/.cargo/registry/src/index.crates.io-6f17d22bba15001f/mio-1.0.2/src/event/source.rs:75:1
    |
75  | pub trait Source {
    | ^^^^^^^^^^^^^^^^

error[E0599]: no method named `reregister` found for struct `IoSource<std::net::UdpSocket>` in the current scope
   --> /Users/ts-sandroama.marques/.cargo/registry/src/index.crates.io-6f17d22bba15001f/mio-1.0.2/src/net/udp.rs:633:20
    |
633 |         self.inner.reregister(registry, token, interests)
    |                    ^^^^^^^^^^ method not found in `IoSource<UdpSocket>`
    |
   ::: /Users/ts-sandroama.marques/.cargo/registry/src/index.crates.io-6f17d22bba15001f/mio-1.0.2/src/io_source.rs:37:1
    |
37  | pub struct IoSource<T> {
    | ---------------------- method `reregister` not found for this struct
    |
    = help: items from traits can only be used if the trait is implemented and in scope
note: `Source` defines an item `reregister`, perhaps you need to implement it
   --> /Users/ts-sandroama.marques/.cargo/registry/src/index.crates.io-6f17d22bba15001f/mio-1.0.2/src/event/source.rs:75:1
    |
75  | pub trait Source {
    | ^^^^^^^^^^^^^^^^

error[E0599]: no method named `deregister` found for struct `IoSource<std::net::UdpSocket>` in the current scope
   --> /Users/ts-sandroama.marques/.cargo/registry/src/index.crates.io-6f17d22bba15001f/mio-1.0.2/src/net/udp.rs:637:20
    |
637 |         self.inner.deregister(registry)
    |                    ^^^^^^^^^^ method not found in `IoSource<UdpSocket>`
    |
   ::: /Users/ts-sandroama.marques/.cargo/registry/src/index.crates.io-6f17d22bba15001f/mio-1.0.2/src/io_source.rs:37:1
    |
37  | pub struct IoSource<T> {
    | ---------------------- method `deregister` not found for this struct
    |
    = help: items from traits can only be used if the trait is implemented and in scope
note: `Source` defines an item `deregister`, perhaps you need to implement it
   --> /Users/ts-sandroama.marques/.cargo/registry/src/index.crates.io-6f17d22bba15001f/mio-1.0.2/src/event/source.rs:75:1
    |
75  | pub trait Source {
    | ^^^^^^^^^^^^^^^^

error[E0308]: mismatched types
   --> /Users/ts-sandroama.marques/.cargo/registry/src/index.crates.io-6f17d22bba15001f/mio-1.0.2/src/net/udp.rs:713:9
    |
713 | /         unsafe {
714 | |             #[cfg(any(unix, target_os = "hermit", target_os = "wasi"))]
715 | |             {
716 | |                 net::UdpSocket::from_raw_fd(socket.into_raw_fd())
...   |
721 | |             }
722 | |         }
    | |_________^ expected `UdpSocket`, found `()`

Some errors have detailed explanations: E0308, E0412, E0425, E0432, E0433, E0599.
For more information about an error, try `rustc --explain E0308`.
error: could not compile `mio` (lib) due to 47 previous errors</code></pre>
</details>
