### PR TITLE
Disable default features in tokio-postgres

### DIFF
--- a/crates/client_async/Cargo.toml
+++ b/crates/client_async/Cargo.toml
@@ -25,7 +25,7 @@ cornucopia_client_core = { path = "../client_core", version = "0.4.0" }
 async-trait = "0.1.63"
 
 # rust-postgres interaction
-tokio-postgres = "0.7.7"
+tokio-postgres = { version = "0.7.7", default-features = false }
 
 # connection pooling
 deadpool-postgres = { version = "0.12.1", optional = true }


### PR DESCRIPTION
tokio-postgres is able to run on Cloudflare workers. Cloudflare workers use wasm32-unknown-unknown arch which is not supported by Tokio. Default features in tokio-postgres mean dependency on Tokio. It would be nice to use Cornucopia in Cloudflare workers.
