### PR TITLE
feat: warn when no queries are found

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,47 @@
-use std::path::PathBuf;
+use std::{io::IsTerminal, path::PathBuf};
 
 use miette::{Diagnostic, GraphicalReportHandler, GraphicalTheme};
 use thiserror::Error as ThisError;
+
+/// Enumeration of all the warnings reported by Cornucopia.
+#[derive(Debug, ThisError, Diagnostic)]
+pub(crate) enum Warning {
+    /// No annotated queries were found in the queries directory.
+    #[error("no queries were found")]
+    #[diagnostic(
+        severity(Warning),
+        help(
+            "Cornucopia only generates code from annotated SQL queries. Make sure your queries directory path is correct and contains annotated queries. See https://cornucopia-rs.github.io/cornucopia/writing_queries/writing_queries.html for more."
+        )
+    )]
+    NoQueries,
+}
+
+impl Warning {
+    fn render(&self, theme: GraphicalTheme) -> String {
+        let mut buff = String::new();
+        if GraphicalReportHandler::new()
+            .with_theme(theme)
+            .render_report(&mut buff, self)
+            .is_err()
+        {
+            format!("Warning: {self}")
+        } else {
+            buff
+        }
+    }
+
+    /// Render this warning and write it to stderr, using ANSI colors when
+    /// stderr is a terminal and `NO_COLOR` is not set.
+    pub(crate) fn emit(&self) {
+        let theme = if std::io::stderr().is_terminal() && std::env::var_os("NO_COLOR").is_none() {
+            GraphicalTheme::unicode()
+        } else {
+            GraphicalTheme::unicode_nocolor()
+        };
+        eprintln!("{}", self.render(theme));
+    }
+}
 
 /// Enumeration of all the errors reported by Cornucopia.
 #[derive(Debug, ThisError, Diagnostic)]
@@ -57,5 +97,19 @@ impl PersistError {
             file_path: path.into(),
             err,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use miette::GraphicalTheme;
+
+    use super::Warning;
+
+    #[test]
+    fn no_queries_warning_renders() {
+        let rendered = Warning::NoQueries.render(GraphicalTheme::unicode_nocolor());
+        assert!(rendered.contains("no queries were found"));
+        assert!(rendered.contains("annotated SQL queries"));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@ use std::path::Path;
 use tokio_postgres::Client;
 
 use config::Config;
-use parser::parse_query_module;
+use parser::{Module, parse_query_module};
 use prepare_queries::prepare;
 use read_queries::read_query_modules;
 
@@ -32,7 +32,15 @@ use read_queries::read_query_modules;
 pub use cli::run;
 
 pub use error::Error;
+use error::Warning;
+
 pub use load_schema::load_schema;
+
+fn warn_if_no_queries(modules: &[Module]) {
+    if modules.iter().all(|m| m.queries.is_empty()) {
+        Warning::NoQueries.emit();
+    }
+}
 
 /// Generates Rust queries from PostgreSQL queries located at `queries_path`,
 /// using a live database managed by you. Code generation settings are
@@ -42,8 +50,10 @@ pub fn gen_live(client: &Client, config: Config) -> Result<(), Error> {
     let modules = read_query_modules(config.queries.as_ref(), &config)?
         .into_iter()
         .map(parse_query_module)
-        .collect::<Result<_, parser::error::Error>>()
+        .collect::<Result<Vec<_>, parser::error::Error>>()
         .map_err(Box::new)?;
+
+    warn_if_no_queries(&modules);
 
     // Generate
     let prepared_modules = prepare(client, modules, &config).map_err(Box::new)?;
@@ -66,8 +76,10 @@ pub fn gen_managed<P: AsRef<Path>>(schema_files: &[P], config: Config) -> Result
     let modules = read_query_modules(config.queries.as_ref(), &config)?
         .into_iter()
         .map(parse_query_module)
-        .collect::<Result<_, parser::error::Error>>()
+        .collect::<Result<Vec<_>, parser::error::Error>>()
         .map_err(Box::new)?;
+
+    warn_if_no_queries(&modules);
 
     container::setup(
         config.podman,
@@ -104,8 +116,10 @@ pub fn gen_fresh<P: AsRef<Path>>(
     let modules = read_query_modules(config.queries.as_ref(), &config)?
         .into_iter()
         .map(parse_query_module)
-        .collect::<Result<_, parser::error::Error>>()
+        .collect::<Result<Vec<_>, parser::error::Error>>()
         .map_err(Box::new)?;
+
+    warn_if_no_queries(&modules);
 
     let server_client = conn::from_url(url)?;
 


### PR DESCRIPTION
Adds a warning when no queries are detected. Also adds the base machinery for emitting warnings.

Closes #260.
