### PR TITLE
fix: avoid pulling in deprecated `rustc-serialize` via `eui48` in tests.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1223,7 +1223,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "887418ac5e8d57c2e66e04bdc2fe15f9a5407be20b54a82c86bd0e368b709701"
 dependencies = [
  "regex",
- "rustc-serialize",
  "serde",
 ]
 
@@ -2672,12 +2671,6 @@ name = "rustc-demangle"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
-
-[[package]]
-name = "rustc-serialize"
-version = "0.3.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe834bc780604f4674073badbad26d7219cadfb4a2275802db12cbae17498401"
 
 [[package]]
 name = "rustix"

--- a/tests/codegen/Cargo.toml
+++ b/tests/codegen/Cargo.toml
@@ -13,5 +13,5 @@ postgres = "0.19.9"
 serde_json = { version = "1.0.135", features = ["raw_value"] }
 chrono = { version = "0.4.44", features = ["serde"] }
 uuid = { version = "1.23", features = ["serde"] }
-eui48 = { version = "1.1.0", features = ["serde"] }
+eui48 = { version = "1.1.0", default-features = false, features = ["serde"] }
 rust_decimal = { version = "1.42.0", features = ["db-postgres"] }


### PR DESCRIPTION
Closes #228 