### PR TITLE
chore: drop no-longer-needed `unused_assignments` allow

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,3 @@
-#![allow(unused_assignments)] // TODO: remove when rustc fixed (thiserror)
-
 mod cli;
 mod codegen;
 mod error;


### PR DESCRIPTION
Fixes #294 