### PR TITLE
feat: bump cornucopia and workspace to Rust edition 2024

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cornucopia"
 version = "0.9.0"
-edition = "2021"
+edition = "2024"
 rust-version = "1.88.0"
 license = "MIT/Apache-2.0"
 description = "Generate type-checked Rust from your PostgreSQL queries."
@@ -75,7 +75,7 @@ harness = false
 path = "benches/codegen.rs"
 
 [workspace]
-resolver = "2"
+resolver = "3"
 members = ["examples/*", "tests/*"]
 exclude = ["examples/basic_async_wasm"]
 

--- a/examples/auto_build/Cargo.toml
+++ b/examples/auto_build/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "auto-build"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 publish = false
 
 [dependencies]

--- a/examples/basic_async/Cargo.toml
+++ b/examples/basic_async/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-edition = "2021"
+edition = "2024"
 name = "basic-async"
 version = "0.1.0"
 publish = false

--- a/examples/basic_async_wasm/Cargo.toml
+++ b/examples/basic_async_wasm/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-edition = "2021"
+edition = "2024"
 name = "basic-async-wasm"
 version = "0.1.0"
 publish = false

--- a/examples/basic_sync/Cargo.toml
+++ b/examples/basic_sync/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "basic_sync"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/examples/custom_types/Cargo.toml
+++ b/examples/custom_types/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-edition = "2021"
+edition = "2024"
 name = "custom-types"
 version = "0.1.0"
 publish = false

--- a/examples/custom_types/db/db_types/Cargo.toml
+++ b/examples/custom_types/db/db_types/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "db_types"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 publish = false
 
 [dependencies]

--- a/src/codegen.rs
+++ b/src/codegen.rs
@@ -130,7 +130,7 @@ pub fn idx_char(idx: usize) -> String {
     format!("T{idx}")
 }
 
-pub(crate) fn gen(preparation: Preparation, config: &Config) -> Vfs {
+pub(crate) fn generate(preparation: Preparation, config: &Config) -> Vfs {
     let mut vfs = Vfs::empty();
     let cargo = cargo::gen_cargo_file(&preparation.dependency_analysis, config);
     vfs.add_string("Cargo.toml", cargo);

--- a/src/codegen/cargo.rs
+++ b/src/codegen/cargo.rs
@@ -149,21 +149,19 @@ impl DependencyContext<'_> {
 
 fn get_workspace_deps(manifest_path: &Path) -> HashSet<String> {
     let mut deps = HashSet::new();
-    if let Ok(contents) = fs::read_to_string(manifest_path) {
-        if let Ok(manifest) = toml::from_str::<cargo_toml::Value>(&contents) {
-            if let Some(workspace) = manifest
-                .get("workspace")
-                .and_then(|w| w.get("dependencies"))
-            {
-                deps.extend(
-                    workspace
-                        .as_table()
-                        .into_iter()
-                        .flat_map(|t| t.keys())
-                        .map(|s| s.to_string()),
-                );
-            }
-        }
+    if let Ok(contents) = fs::read_to_string(manifest_path)
+        && let Ok(manifest) = toml::from_str::<cargo_toml::Value>(&contents)
+        && let Some(workspace) = manifest
+            .get("workspace")
+            .and_then(|w| w.get("dependencies"))
+    {
+        deps.extend(
+            workspace
+                .as_table()
+                .into_iter()
+                .flat_map(|t| t.keys())
+                .map(|s| s.to_string()),
+        );
     }
     deps
 }

--- a/src/codegen/queries.rs
+++ b/src/codegen/queries.rs
@@ -703,7 +703,7 @@ fn gen_specific(
 
 pub(crate) fn gen_queries(vfs: &mut Vfs, preparation: &Preparation, config: &Config) {
     for module in &preparation.modules {
-        let gen = gen_query_module(module, config);
+        let module_tokens = gen_query_module(module, config);
 
         let path_components: Vec<&str> = module.info.full_module_path.split("::").collect();
         let file_name = &module.info.name;
@@ -717,7 +717,7 @@ pub(crate) fn gen_queries(vfs: &mut Vfs, preparation: &Preparation, config: &Con
 
         let file_path = format!("{dir_path}/{file_name}.rs");
 
-        vfs.add(file_path, gen);
+        vfs.add(file_path, module_tokens);
     }
 
     let module_tree = crate::read_queries::build_module_hierarchy(

--- a/src/codegen/vfs.rs
+++ b/src/codegen/vfs.rs
@@ -192,23 +192,23 @@ impl Vfs {
         };
 
         // If something went wrong and we have a backup, restore it
-        if result.is_err() {
-            if let Some(backup_dir) = backup_dir {
-                // Clean the destination directory if it exists after a failed operation
-                if destination.exists() {
-                    let _ = std::fs::remove_dir_all(destination);
-                }
+        if result.is_err()
+            && let Some(backup_dir) = backup_dir
+        {
+            // Clean the destination directory if it exists after a failed operation
+            if destination.exists() {
+                let _ = std::fs::remove_dir_all(destination);
+            }
 
-                // Ensure the destination directory exists for restoration
-                let _ = std::fs::create_dir_all(destination);
+            // Ensure the destination directory exists for restoration
+            let _ = std::fs::create_dir_all(destination);
 
-                // Restore from backup
-                if let Err(restore_err) = copy_dir_recursive(backup_dir.path(), destination) {
-                    // If restoration also fails, return a compound error
-                    return Err(PersistError::wrap(
-                        "failed to restore backup after generation error",
-                    )(restore_err));
-                }
+            // Restore from backup
+            if let Err(restore_err) = copy_dir_recursive(backup_dir.path(), destination) {
+                // If restoration also fails, return a compound error
+                return Err(PersistError::wrap(
+                    "failed to restore backup after generation error",
+                )(restore_err));
             }
         }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -61,10 +61,10 @@ impl Config {
             config.manifest.package = default_manifest().package;
         }
 
-        if let Some(manifest) = &mut config.manifest.package {
-            if manifest.edition == cargo_toml::Inheritable::Set(cargo_toml::Edition::E2015) {
-                manifest.edition = cargo_toml::Inheritable::Set(cargo_toml::Edition::E2021);
-            }
+        if let Some(manifest) = &mut config.manifest.package
+            && manifest.edition == cargo_toml::Inheritable::Set(cargo_toml::Edition::E2015)
+        {
+            manifest.edition = cargo_toml::Inheritable::Set(cargo_toml::Edition::E2021);
         }
 
         config.check_deprecated_fields();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,7 +55,7 @@ pub fn gen_live(client: &Client, config: Config) -> Result<(), Error> {
 
     // Generate
     let prepared_modules = prepare(client, modules, &config).map_err(Box::new)?;
-    let generated = codegen::gen(prepared_modules, &config);
+    let generated = codegen::generate(prepared_modules, &config);
 
     // Write
     generated.persist(config.destination, config.static_files)?;
@@ -88,7 +88,7 @@ pub fn gen_managed<P: AsRef<Path>>(schema_files: &[P], config: Config) -> Result
     let client = conn::cornucopia_conn()?;
     load_schema(&client, schema_files).map_err(Box::new)?;
     let prepared_modules = prepare(&client, modules, &config).map_err(Box::new)?;
-    let generated = codegen::gen(prepared_modules, &config);
+    let generated = codegen::generate(prepared_modules, &config);
     container::cleanup(config.podman)?;
 
     // Write
@@ -143,7 +143,7 @@ pub fn gen_fresh<P: AsRef<Path>>(
         load_schema(&db_client, schema_files).map_err(Box::new)?;
 
         let prepared_modules = prepare(&db_client, modules, &config).map_err(Box::new)?;
-        let generated = codegen::gen(prepared_modules, &config);
+        let generated = codegen::generate(prepared_modules, &config);
 
         generated.persist(config.destination, config.static_files)?;
 

--- a/src/read_queries.rs
+++ b/src/read_queries.rs
@@ -75,12 +75,12 @@ fn read_query_modules_recursive(
 
         if path_buf.is_dir() {
             // Skip directories starting with underscore if configured to do so
-            if let Some(dir_name) = path_buf.file_name() {
-                if let Some(dir_name_str) = dir_name.to_str() {
-                    if config.ignore_underscore_files && dir_name_str.starts_with('_') {
-                        continue;
-                    }
-                }
+            if let Some(dir_name) = path_buf.file_name()
+                && let Some(dir_name_str) = dir_name.to_str()
+                && config.ignore_underscore_files
+                && dir_name_str.starts_with('_')
+            {
+                continue;
             }
 
             // Recursively process subdirectory

--- a/tests/codegen/Cargo.toml
+++ b/tests/codegen/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "test_codegen"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 publish = false
 
 [dependencies]

--- a/tests/integration/Cargo.toml
+++ b/tests/integration/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "test_integration"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 publish = false
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
Cornucopia itself and all non-generated workspace crates move to edition 2024. Workspace resolver moves to "3" (the default for 2024).

Side-effect changes required by 2024:
- Renamed the codegen entry point from `gen` to `generate` since `gen` is now a reserved keyword.
- Collapsed nested `if let` blocks into let-chains where new clippy lints flagged them.