### PR TITLE
feat: Use query_typed and variants

### DIFF
--- a/src/codegen/client.rs
+++ b/src/codegen/client.rs
@@ -27,7 +27,7 @@ pub(crate) fn gen_lib(
         mod type_traits;
         mod utils;
 
-        pub(crate) use utils::slice_iter;
+        pub(crate) use utils::{slice_iter, slice_iter_typed};
 
         pub use array_iterator::ArrayIterator;
         pub use domain::{Domain, DomainArray};
@@ -127,6 +127,12 @@ pub fn core_utils() -> proc_macro2::TokenStream {
             s: &'a [&'a (dyn ToSql + Sync)],
         ) -> impl ExactSizeIterator<Item = &'a dyn ToSql> + 'a {
             s.iter().map(|s| *s as _)
+        }
+
+        pub fn slice_iter_typed<'a>(
+            s: &'a [(&'a (dyn ToSql + Sync), Type)],
+        ) -> impl ExactSizeIterator<Item = (&'a dyn ToSql, Type)> + 'a {
+            s.iter().map(|(s, t)| (*s as _, t.clone()))
         }
     }
 }
@@ -506,6 +512,7 @@ pub fn sync() -> proc_macro2::TokenStream {
             client: &mut C,
             query: &str,
             params: &[&(dyn ToSql + Sync)],
+            typed_params: &[(&(dyn ToSql + Sync), postgres_types::Type)],
             cached: Option<&Statement>,
         ) -> Result<Row, Error> {
             if let Some(cached) = cached {
@@ -514,7 +521,7 @@ pub fn sync() -> proc_macro2::TokenStream {
                 let cached = client.prepare(query)?;
                 client.query_one(&cached, params)
             } else {
-                client.query_one(query, params)
+                client.query_typed_one(query, typed_params)
             }
         }
 
@@ -522,6 +529,7 @@ pub fn sync() -> proc_macro2::TokenStream {
             client: &mut C,
             query: &str,
             params: &[&(dyn ToSql + Sync)],
+            typed_params: &[(&(dyn ToSql + Sync), postgres_types::Type)],
             cached: Option<&Statement>,
         ) -> Result<Option<Row>, Error> {
             if let Some(cached) = cached {
@@ -530,20 +538,23 @@ pub fn sync() -> proc_macro2::TokenStream {
                 let cached = client.prepare(query)?;
                 client.query_opt(&cached, params)
             } else {
-                client.query_opt(query, params)
+                client.query_typed_opt(query, typed_params)
             }
         }
 
-        pub fn raw<'a, C: GenericClient, P, I>(
+        pub fn raw<'a, C: GenericClient, P, I, Ty>(
             client: &'a mut C,
             query: &str,
             params: I,
+            typed_params: Ty,
             cached: Option<&Statement>,
         ) -> Result<RowIter<'a>, Error>
         where
             P: BorrowToSql,
             I: IntoIterator<Item = P>,
             I::IntoIter: ExactSizeIterator,
+            Ty: IntoIterator<Item = (P, postgres_types::Type)>,
+            Ty::IntoIter: ExactSizeIterator,
         {
             if let Some(cached) = cached {
                 client.query_raw(cached, params)
@@ -551,7 +562,7 @@ pub fn sync() -> proc_macro2::TokenStream {
                 let cached = client.prepare(query)?;
                 client.query_raw(&cached, params)
             } else {
-                client.query_raw(query, params)
+                client.query_typed_raw(query, typed_params)
             }
         }
     }
@@ -580,6 +591,7 @@ pub fn async_() -> proc_macro2::TokenStream {
             client: &C,
             query: &str,
             params: &[&(dyn ToSql + Sync)],
+            typed_params: &[(&(dyn ToSql + Sync), postgres_types::Type)],
             cached: Option<&Statement>,
         ) -> Result<Row, Error> {
             if let Some(cached) = cached {
@@ -588,7 +600,7 @@ pub fn async_() -> proc_macro2::TokenStream {
                 let cached = client.prepare(query).await?;
                 client.query_one(&cached, params).await
             } else {
-                client.query_one(query, params).await
+                client.query_typed_one(query, typed_params).await
             }
         }
 
@@ -596,6 +608,7 @@ pub fn async_() -> proc_macro2::TokenStream {
             client: &C,
             query: &str,
             params: &[&(dyn ToSql + Sync)],
+            typed_params: &[(&(dyn ToSql + Sync), postgres_types::Type)],
             cached: Option<&Statement>,
         ) -> Result<Option<Row>, Error> {
             if let Some(cached) = cached {
@@ -604,19 +617,18 @@ pub fn async_() -> proc_macro2::TokenStream {
                 let cached = client.prepare(query).await?;
                 client.query_opt(&cached, params).await
             } else {
-                client.query_opt(query, params).await
+                client.query_typed_opt(query, typed_params).await
             }
         }
 
-        pub async fn raw<C: GenericClient, P, I>(
+        pub async fn raw<C: GenericClient, P: BorrowToSql, I: IntoIterator<Item = P> + Sync + Send>(
             client: &C,
             query: &str,
             params: I,
+            typed_params: &[(&(dyn ToSql + Sync), postgres_types::Type)],
             cached: Option<&Statement>,
         ) -> Result<RowStream, Error>
         where
-            P: BorrowToSql,
-            I: IntoIterator<Item = P> + Sync + Send,
             I::IntoIter: ExactSizeIterator,
         {
             if let Some(cached) = cached {
@@ -625,7 +637,7 @@ pub fn async_() -> proc_macro2::TokenStream {
                 let cached = client.prepare(query).await?;
                 client.query_raw(&cached, params).await
             } else {
-                client.query_raw(query, params).await
+                client.query_typed_raw(query, typed_params).await
             }
         }
     }
@@ -655,6 +667,12 @@ pub fn sync_generic_client() -> proc_macro2::TokenStream {
             where
                 T: ?Sized + ToStatement;
 
+            fn query_typed_one(
+                &mut self,
+                query: &str,
+                typed_params: &[(&(dyn ToSql + Sync), postgres_types::Type)],
+            ) -> Result<Row, Error>;
+
             fn query_opt<T>(
                 &mut self,
                 statement: &T,
@@ -662,6 +680,12 @@ pub fn sync_generic_client() -> proc_macro2::TokenStream {
             ) -> Result<Option<Row>, Error>
             where
                 T: ?Sized + ToStatement;
+
+            fn query_typed_opt(
+                &mut self,
+                query: &str,
+                typed_params: &[(&(dyn ToSql + Sync), postgres_types::Type)],
+            ) -> Result<Option<Row>, Error>;
 
             fn query<T>(&mut self, query: &T, params: &[&(dyn ToSql + Sync)]) -> Result<Vec<Row>, Error>
             where
@@ -673,6 +697,12 @@ pub fn sync_generic_client() -> proc_macro2::TokenStream {
                 P: BorrowToSql,
                 I: IntoIterator<Item = P>,
                 I::IntoIter: ExactSizeIterator;
+
+            fn query_typed_raw(
+                &mut self,
+                query: &str,
+                typed_params: &[(&(dyn ToSql + Sync), postgres_types::Type)]
+            ) -> Result<RowIter<'_>, Error>;
         }
 
         impl GenericClient for Transaction<'_> {
@@ -694,6 +724,14 @@ pub fn sync_generic_client() -> proc_macro2::TokenStream {
                 Transaction::query_one(self, statement, params)
             }
 
+            fn query_typed_one(
+                &mut self,
+                query: &str,
+                typed_params: &[(&(dyn ToSql + Sync), postgres_types::Type)],
+            ) -> Result<Row, Error> {
+                Transaction::query_typed_one(self, query, typed_params)
+            }
+
             fn query_opt<T>(
                 &mut self,
                 statement: &T,
@@ -703,6 +741,14 @@ pub fn sync_generic_client() -> proc_macro2::TokenStream {
                 T: ?Sized + ToStatement,
             {
                 Transaction::query_opt(self, statement, params)
+            }
+
+            fn query_typed_opt(
+                &mut self,
+                query: &str,
+                typed_params: &[(&(dyn ToSql + Sync), postgres_types::Type)],
+            ) -> Result<Option<Row>, Error> {
+                Transaction::query_typed_opt(self, query, typed_params)
             }
 
             fn query<T>(&mut self, query: &T, params: &[&(dyn ToSql + Sync)]) -> Result<Vec<Row>, Error>
@@ -720,6 +766,14 @@ pub fn sync_generic_client() -> proc_macro2::TokenStream {
                 I::IntoIter: ExactSizeIterator,
             {
                 Transaction::query_raw(self, statement, params)
+            }
+
+            fn query_typed_raw(
+                &mut self,
+                query: &str,
+                typed_params: &[(&(dyn ToSql + Sync), postgres_types::Type)]
+            ) -> Result<RowIter<'_>, Error> {
+                Transaction::query_typed_raw(self, query, crate::slice_iter_typed(typed_params))
             }
         }
 
@@ -742,6 +796,14 @@ pub fn sync_generic_client() -> proc_macro2::TokenStream {
                 Client::query_one(self, statement, params)
             }
 
+            fn query_typed_one(
+                &mut self,
+                query: &str,
+                typed_params: &[(&(dyn ToSql + Sync), postgres_types::Type)],
+            ) -> Result<Row, Error> {
+                Client::query_typed_one(self, query, typed_params)
+            }
+
             fn query_opt<T>(
                 &mut self,
                 statement: &T,
@@ -751,6 +813,14 @@ pub fn sync_generic_client() -> proc_macro2::TokenStream {
                 T: ?Sized + ToStatement,
             {
                 Client::query_opt(self, statement, params)
+            }
+
+            fn query_typed_opt(
+                &mut self,
+                query: &str,
+                typed_params: &[(&(dyn ToSql + Sync), postgres_types::Type)],
+            ) -> Result<Option<Row>, Error> {
+                Client::query_typed_opt(self, query, typed_params)
             }
 
             fn query<T>(&mut self, query: &T, params: &[&(dyn ToSql + Sync)]) -> Result<Vec<Row>, Error>
@@ -768,6 +838,14 @@ pub fn sync_generic_client() -> proc_macro2::TokenStream {
                 I::IntoIter: ExactSizeIterator,
             {
                 Client::query_raw(self, statement, params)
+            }
+
+            fn query_typed_raw(
+                &mut self,
+                query: &str,
+                typed_params: &[(&(dyn ToSql + Sync), postgres_types::Type)]
+            ) -> Result<RowIter<'_>, Error> {
+                Client::query_typed_raw(self, query, crate::slice_iter_typed(typed_params))
             }
         }
     }
@@ -809,6 +887,12 @@ pub fn async_generic_client() -> proc_macro2::TokenStream {
             where
                 T: ?Sized + ToStatement + Sync + Send;
 
+            fn query_typed_one(
+                &self,
+                query: &str,
+                typed_params: &[(&(dyn ToSql + Sync), postgres_types::Type)],
+            ) -> impl Future<Output = Result<Row, Error>> + Send;
+
             fn query_opt<T>(
                 &self,
                 statement: &T,
@@ -816,6 +900,12 @@ pub fn async_generic_client() -> proc_macro2::TokenStream {
             ) -> impl Future<Output = Result<Option<Row>, Error>> + Send
             where
                 T: ?Sized + ToStatement + Sync + Send;
+
+            fn query_typed_opt(
+                &self,
+                query: &str,
+                typed_params: &[(&(dyn ToSql + Sync), postgres_types::Type)],
+            ) -> impl Future<Output = Result<Option<Row>, Error>> + Send;
 
             fn query<T>(
                 &self,
@@ -835,6 +925,12 @@ pub fn async_generic_client() -> proc_macro2::TokenStream {
                 I: IntoIterator + Sync + Send,
                 I::IntoIter: ExactSizeIterator,
                 I::Item: BorrowToSql;
+
+            fn query_typed_raw(
+                &self,
+                query: &str,
+                typed_params: &[(&(dyn ToSql + Sync), postgres_types::Type)],
+            ) -> impl Future<Output = Result<RowStream, Error>> + Send;
         }
 
         impl GenericClient for Transaction<'_> {
@@ -864,6 +960,14 @@ pub fn async_generic_client() -> proc_macro2::TokenStream {
                 Transaction::query_one(self, statement, params).await
             }
 
+            async fn query_typed_one(
+                &self,
+                query: &str,
+                typed_params: &[(&(dyn ToSql + Sync), postgres_types::Type)],
+            ) -> Result<Row, Error> {
+                Transaction::query_typed_one(self, query, typed_params).await
+            }
+
             async fn query_opt<T>(
                 &self,
                 statement: &T,
@@ -873,6 +977,14 @@ pub fn async_generic_client() -> proc_macro2::TokenStream {
                 T: ?Sized + ToStatement + Sync + Send,
             {
                 Transaction::query_opt(self, statement, params).await
+            }
+
+            async fn query_typed_opt(
+                &self,
+                query: &str,
+                typed_params: &[(&(dyn ToSql + Sync), postgres_types::Type)],
+            ) -> Result<Option<Row>, Error> {
+                Transaction::query_typed_opt(self, query, typed_params).await
             }
 
             async fn query<T>(
@@ -894,6 +1006,14 @@ pub fn async_generic_client() -> proc_macro2::TokenStream {
                 I::Item: BorrowToSql,
             {
                 Transaction::query_raw(self, statement, params).await
+            }
+
+            async fn query_typed_raw(
+                &self,
+                query: &str,
+                typed_params: &[(&(dyn ToSql + Sync), postgres_types::Type)]
+            ) -> Result<RowStream, Error> {
+                Transaction::query_typed_raw(self, query, crate::slice_iter_typed(typed_params)).await
             }
         }
 
@@ -924,6 +1044,14 @@ pub fn async_generic_client() -> proc_macro2::TokenStream {
                 Client::query_one(self, statement, params).await
             }
 
+            async fn query_typed_one(
+                &self,
+                query: &str,
+                typed_params: &[(&(dyn ToSql + Sync), postgres_types::Type)],
+            ) -> Result<Row, Error> {
+                Client::query_typed_one(self, query, typed_params).await
+            }
+
             async fn query_opt<T>(
                 &self,
                 statement: &T,
@@ -933,6 +1061,14 @@ pub fn async_generic_client() -> proc_macro2::TokenStream {
                 T: ?Sized + ToStatement + Sync + Send,
             {
                 Client::query_opt(self, statement, params).await
+            }
+
+            async fn query_typed_opt(
+                &self,
+                query: &str,
+                typed_params: &[(&(dyn ToSql + Sync), postgres_types::Type)],
+            ) -> Result<Option<Row>, Error> {
+                Client::query_typed_opt(self, query, typed_params).await
             }
 
             async fn query<T>(
@@ -954,6 +1090,14 @@ pub fn async_generic_client() -> proc_macro2::TokenStream {
                 I::Item: BorrowToSql,
             {
                 Client::query_raw(self, statement, params).await
+            }
+
+            async fn query_typed_raw(
+                &self,
+                query: &str,
+                typed_params: &[(&(dyn ToSql + Sync), postgres_types::Type)]
+            ) -> Result<RowStream, Error> {
+                Client::query_typed_raw(self, query, crate::slice_iter_typed(typed_params)).await
             }
         }
     }
@@ -1002,6 +1146,14 @@ pub fn async_deadpool() -> proc_macro2::TokenStream {
                 PgClient::query_one(self, statement, params).await
             }
 
+            async fn query_typed_one(
+                &self,
+                query: &str,
+                typed_params: &[(&(dyn tokio_postgres::types::ToSql + Sync), postgres_types::Type)],
+            ) -> Result<tokio_postgres::Row, Error> {
+                PgClient::query_typed_one(self, query, typed_params).await
+            }
+
             async fn query_opt<T>(
                 &self,
                 statement: &T,
@@ -1011,6 +1163,14 @@ pub fn async_deadpool() -> proc_macro2::TokenStream {
                 T: ?Sized + tokio_postgres::ToStatement + Sync + Send,
             {
                 PgClient::query_opt(self, statement, params).await
+            }
+
+            async fn query_typed_opt(
+                &self,
+                query: &str,
+                typed_params: &[(&(dyn tokio_postgres::types::ToSql + Sync), postgres_types::Type)],
+            ) -> Result<Option<tokio_postgres::Row>, Error> {
+                PgClient::query_typed_opt(self, query, typed_params).await
             }
 
             async fn query<T>(
@@ -1032,6 +1192,14 @@ pub fn async_deadpool() -> proc_macro2::TokenStream {
                 I::Item: BorrowToSql,
             {
                 PgClient::query_raw(self, statement, params).await
+            }
+
+            async fn query_typed_raw(
+                &self,
+                query: &str,
+                typed_params: &[(&(dyn tokio_postgres::types::ToSql + Sync), postgres_types::Type)]
+            ) -> Result<RowStream, Error> {
+                PgClient::query_typed_raw(self, query, crate::slice_iter_typed(typed_params)).await
             }
         }
 
@@ -1066,6 +1234,14 @@ pub fn async_deadpool() -> proc_macro2::TokenStream {
                 PgTransaction::query_one(self, statement, params).await
             }
 
+            async fn query_typed_one(
+                &self,
+                query: &str,
+                typed_params: &[(&(dyn tokio_postgres::types::ToSql + Sync), postgres_types::Type)],
+            ) -> Result<tokio_postgres::Row, Error> {
+                PgTransaction::query_typed_one(self, query, typed_params).await
+            }
+
             async fn query_opt<T>(
                 &self,
                 statement: &T,
@@ -1075,6 +1251,14 @@ pub fn async_deadpool() -> proc_macro2::TokenStream {
                 T: ?Sized + tokio_postgres::ToStatement + Sync + Send,
             {
                 PgTransaction::query_opt(self, statement, params).await
+            }
+
+            async fn query_typed_opt(
+                &self,
+                query: &str,
+                typed_params: &[(&(dyn tokio_postgres::types::ToSql + Sync), postgres_types::Type)],
+            ) -> Result<Option<tokio_postgres::Row>, Error> {
+                PgTransaction::query_typed_opt(self, query, typed_params).await
             }
 
             async fn query<T>(
@@ -1096,6 +1280,14 @@ pub fn async_deadpool() -> proc_macro2::TokenStream {
                 I::Item: BorrowToSql,
             {
                 PgTransaction::query_raw(self, statement, params).await
+            }
+
+            async fn query_typed_raw(
+                &self,
+                query: &str,
+                typed_params: &[(&(dyn tokio_postgres::types::ToSql + Sync), postgres_types::Type)]
+            ) -> Result<RowStream, Error> {
+                PgTransaction::query_typed_raw(self, query, crate::slice_iter_typed(typed_params)).await
             }
         }
     }

--- a/src/codegen/client.rs
+++ b/src/codegen/client.rs
@@ -663,6 +663,8 @@ pub fn sync_generic_client() -> proc_macro2::TokenStream {
             where
                 T: ?Sized + ToStatement;
 
+            fn execute_typed(&mut self, query: &str, typed_params: &[(&(dyn ToSql + Sync), postgres_types::Type)]) -> Result<u64, Error>;
+
             fn query_one<T>(&mut self, statement: &T, params: &[&(dyn ToSql + Sync)]) -> Result<Row, Error>
             where
                 T: ?Sized + ToStatement;
@@ -715,6 +717,11 @@ pub fn sync_generic_client() -> proc_macro2::TokenStream {
                 T: ?Sized + ToStatement,
             {
                 Transaction::execute(self, query, params)
+            }
+
+            fn execute_typed(&mut self, query: &str, typed_params: &[(&(dyn ToSql + Sync), postgres_types::Type)]) -> Result<u64, Error>
+            {
+                Transaction::execute_typed(self, query, typed_params)
             }
 
             fn query_one<T>(&mut self, statement: &T, params: &[&(dyn ToSql + Sync)]) -> Result<Row, Error>
@@ -787,6 +794,11 @@ pub fn sync_generic_client() -> proc_macro2::TokenStream {
                 T: ?Sized + ToStatement,
             {
                 Client::execute(self, query, params)
+            }
+
+            fn execute_typed(&mut self, query: &str, typed_params: &[(&(dyn ToSql + Sync), postgres_types::Type)]) -> Result<u64, Error>
+            {
+                Client::execute_typed(self, query, typed_params)
             }
 
             fn query_one<T>(&mut self, statement: &T, params: &[&(dyn ToSql + Sync)]) -> Result<Row, Error>
@@ -879,6 +891,12 @@ pub fn async_generic_client() -> proc_macro2::TokenStream {
             where
                 T: ?Sized + ToStatement + Sync + Send;
 
+            fn execute_typed(
+                &self,
+                query: &str,
+                typed_params: &[(&(dyn ToSql + Sync), postgres_types::Type)],
+            ) -> impl Future<Output = Result<u64, Error>> + Send;
+
             fn query_one<T>(
                 &self,
                 statement: &T,
@@ -947,6 +965,15 @@ pub fn async_generic_client() -> proc_macro2::TokenStream {
                 T: ?Sized + ToStatement + Sync + Send,
             {
                 Transaction::execute(self, query, params).await
+            }
+
+            async fn execute_typed(
+                &self,
+                query: &str,
+                typed_params: &[(&(dyn ToSql + Sync), postgres_types::Type)],
+            ) -> Result<u64, Error>
+            {
+                Transaction::execute_typed(self, query, typed_params).await
             }
 
             async fn query_one<T>(
@@ -1031,6 +1058,15 @@ pub fn async_generic_client() -> proc_macro2::TokenStream {
                 T: ?Sized + ToStatement + Sync + Send,
             {
                 Client::execute(self, query, params).await
+            }
+
+            async fn execute_typed(
+                &self,
+                query: &str,
+                typed_params: &[(&(dyn ToSql + Sync), postgres_types::Type)],
+            ) -> Result<u64, Error>
+            {
+                Client::execute_typed(self, query, typed_params).await
             }
 
             async fn query_one<T>(
@@ -1135,6 +1171,15 @@ pub fn async_deadpool() -> proc_macro2::TokenStream {
                 PgClient::execute(self, query, params).await
             }
 
+            async fn execute_typed(
+                &self,
+                query: &str,
+                typed_params: &[(&(dyn tokio_postgres::types::ToSql + Sync), postgres_types::Type)],
+            ) -> Result<u64, Error>
+            {
+                PgClient::execute_typed(self, query, typed_params).await
+            }
+
             async fn query_one<T>(
                 &self,
                 statement: &T,
@@ -1221,6 +1266,15 @@ pub fn async_deadpool() -> proc_macro2::TokenStream {
                 T: ?Sized + tokio_postgres::ToStatement + Sync + Send,
             {
                 PgTransaction::execute(self, query, params).await
+            }
+
+            async fn execute_typed(
+                &self,
+                query: &str,
+                typed_params: &[(&(dyn tokio_postgres::types::ToSql + Sync), postgres_types::Type)],
+            ) -> Result<u64, Error>
+            {
+                PgTransaction::execute_typed(self, query, typed_params).await
             }
 
             async fn query_one<T>(

--- a/src/codegen/queries.rs
+++ b/src/codegen/queries.rs
@@ -267,6 +267,7 @@ fn gen_row_query(row: &PreparedItem, ctx: &GenCtx) -> proc_macro2::TokenStream {
         pub struct #name_ident<'c, 'a, 's, C: GenericClient, T, const N: usize> {
             client: &'c #client_mut C,
             params: [&'a (dyn postgres_types::ToSql + Sync); N],
+            typed_params: [(&'a (dyn postgres_types::ToSql + Sync), postgres_types::Type); N],
             query: &'static str,
             cached: Option<&'s #backend::Statement>,
             extractor: fn(&#backend::Row) -> Result<#row_struct, #backend::Error>,
@@ -281,6 +282,7 @@ fn gen_row_query(row: &PreparedItem, ctx: &GenCtx) -> proc_macro2::TokenStream {
                 #name_ident {
                     client: self.client,
                     params: self.params,
+                    typed_params: self.typed_params,
                     query: self.query,
                     cached: self.cached,
                     extractor: self.extractor,
@@ -289,7 +291,7 @@ fn gen_row_query(row: &PreparedItem, ctx: &GenCtx) -> proc_macro2::TokenStream {
             }
 
             pub #fn_async fn one(self) -> Result<T, #backend::Error> {
-                let row = #client::one(self.client, self.query, &self.params, self.cached)#fn_await?;
+                let row = #client::one(self.client, self.query, &self.params, &self.typed_params, self.cached)#fn_await?;
                 Ok((self.mapper)((self.extractor)(&row)?))
             }
 
@@ -298,7 +300,7 @@ fn gen_row_query(row: &PreparedItem, ctx: &GenCtx) -> proc_macro2::TokenStream {
             }
 
             pub #fn_async fn opt(self) -> Result<Option<T>, #backend::Error> {
-                let opt_row = #client::opt(self.client, self.query, &self.params, self.cached)#fn_await?;
+                let opt_row = #client::opt(self.client, self.query, &self.params, &self.typed_params, self.cached)#fn_await?;
                 Ok(opt_row
                     .map(|row| {
                         let extracted = (self.extractor)(&row)?;
@@ -310,7 +312,7 @@ fn gen_row_query(row: &PreparedItem, ctx: &GenCtx) -> proc_macro2::TokenStream {
             pub #fn_async fn iter(
                 self,
             ) -> Result<impl #raw_type<Item = Result<T, #backend::Error>> + 'c, #backend::Error> {
-                let stream = #client::raw(self.client, self.query, crate::slice_iter(&self.params), self.cached)#fn_await?;
+                let stream = #client::raw(self.client, self.query, crate::slice_iter(&self.params), &self.typed_params, self.cached)#fn_await?;
                 let mapped = stream
                     #raw_pre
                     .map(move |res|
@@ -370,6 +372,26 @@ fn gen_query_fn(
         .iter()
         .map(|idx| {
             syn::parse_str::<syn::Type>(&param_field[*idx].param_ergo_ty(traits, ctx)).unwrap()
+        })
+        .collect();
+
+    let params_ty_val: Vec<_> = order
+        .iter()
+        .map(|idx| {
+            let pg_ty = param_field[*idx].ty.pg_ty();
+            let ty_str = match pg_ty.clone() {
+                postgres_types::Type::UUID => "postgres_types::Type::UUID".to_string(),
+                postgres_types::Type::TEXT => "postgres_types::Type::TEXT".to_string(),
+                postgres_types::Type::VARCHAR => "postgres_types::Type::VARCHAR".to_string(),
+                postgres_types::Type::INT4 => "postgres_types::Type::INT4".to_string(),
+                postgres_types::Type::TIMESTAMPTZ => {
+                    "postgres_types::Type::TIMESTAMPTZ".to_string()
+                }
+                pg_ty => unimplemented!("{}", pg_ty),
+            };
+            syn::parse_str::<syn::Type>(&ty_str).unwrap()
+            // param_field[*idx].
+            // syn::parse_str::<syn::Type>(&param_field[*idx].param_ergo_ty(traits, ctx)).unwrap()
         })
         .collect();
 
@@ -446,6 +468,7 @@ fn gen_query_fn(
                     #row_name_query_ident {
                         client,
                         params: [#(#params_name,)*],
+                        typed_params: [#((#params_name, #params_ty_val),)*],
                         query: self.0,
                         cached: self.1.as_ref(),
                         extractor: #extractor,
@@ -467,6 +490,7 @@ fn gen_query_fn(
                     #row_name_query_ident {
                         client,
                         params: [#(#params_name,)*],
+                        typed_params: [#((#params_name, #params_ty_val),)*],
                         query: self.0,
                         cached: self.1.as_ref(),
                         extractor: |row| Ok(row.try_get(0)?),

--- a/src/codegen/queries.rs
+++ b/src/codegen/queries.rs
@@ -514,7 +514,7 @@ fn gen_query_fn(
                 client: &'c #client_mut C,
                 #(#params_name: &'a #params_ty,)*
             ) -> Result<u64, #backend::Error> {
-                client.execute(self.0, &[#(#params_wrap,)*])#fn_await
+                client.execute_typed(self.0, &[#((#params_wrap, #params_ty_val),)*])#fn_await
             }
         }
     };


### PR DESCRIPTION
Closes https://github.com/cornucopia-rs/cornucopia/issues/283

As described in https://github.com/rust-postgres/rust-postgres/pull/1147, only `query_typed` and variants are usable with some connection pools because non-typed `query` prepares statements just to obtain param types.

This PR uses `query_typed` if prepared statements are not needed. Such scenario is common for serverless apps. For example code generated by this fork works well with Cloudflare Hyperdrive.

Yeah also it should improve performance a bit if prepared statements are not used

However there are a few things that need to be discussed:
- `postgres_types::Type` is surprisingly rich. How do we express it during codegen? I covered some simple types but that's not enough.  Maybe there is some way to serialize it? Or, maybe we should fall back to non-typed `query` if a type can't be expressed?
- If non-typed `query` fallback will not be used, non-typed `params` can also be removed.
- I guess more tests should be added because 'postgres_types::Type' can't be tested at compile time and wrong type will cause runtime errors
- Is it intentional that `clorinde::client::async_::raw` uses that `IntoIterator` for `params` instead of a simple slice like `clorinde::client::async_::one`? I have not managed to use `IntoIterator` for `typed_params` because it makes futures non-Send (I believe it also should be tested), while slices work just nice
- Do `src/codegen/client.rs` becomes too bloated? I just added typed variant for almost every method of every client implementation and trait - lots of code that may be generated using some # magic in quote! instead of repeating things

### How has this been tested?
I have not ran tests or benchmarks yet, and have not tried to generate sync code, but this seem to work.

At the time of writing this PR is a draft

### The following has been done
<!-- Mark each item as done by replace the space in '[ ]' with an 'x', e.g. '[x]' -->

- [x] PR title is prefixed with `feat:`, `fix:`, `chore:`, or `docs:`
- [x] The message body above clearly illustrates what problems it solves
- [ ] If this PR has changed code within `src`, codegen for the repo has been run with `cargo run --package test_integration -- --apply-codegen`

### Tests and linting

- [ ] Formatting has been run with `cargo fmt`
- [ ] Tests and lints have been run with `cargo test --all` and `cargo clippy`
